### PR TITLE
Change block category taxonomy to private

### DIFF
--- a/inc/block_editor/namespace.php
+++ b/inc/block_editor/namespace.php
@@ -35,7 +35,7 @@ function register_block_categories() {
 			'not_found'                  => __( 'No block categories found.', 'altis' ),
 			'menu_name'                  => __( 'Categories', 'altis' ),
 		],
-		'public' => true,
+		'public' => false,
 		'publicly_queryable' => false,
 		'show_ui' => true,
 		'show_in_nav_menus' => false,


### PR DESCRIPTION
This taxonomy doesn't need to be set to public as other plugins use that to determine whether to extend the edit screen with client side features such as SEO meta fields.