### PR TITLE
Remove nonexistant hook function

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -68,7 +68,6 @@ function remove_emoji() {
 	remove_filter( 'the_content_feed', 'wp_staticize_emoji' );
 	remove_filter( 'comment_text_rss', 'wp_staticize_emoji' );
 	remove_filter( 'wp_mail', 'wp_staticize_emoji_for_email' );
-	add_filter( 'tiny_mce_plugins', 'disable_emojis_tinymce' );
 	add_filter( 'wp_resource_hints', __NAMESPACE__ . '\\disable_emojis_remove_dns_prefetch', 10, 2 );
 }
 


### PR DESCRIPTION
This was introduced in https://github.com/humanmade/altis-cms/pull/83/commits/457b5eaf8e016dda276ccf1fd4ba347b86ddb77b, but this function was never defined.