### PR TITLE
Move remove_emoji callback to plugins_loaded

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -53,7 +53,7 @@ function bootstrap() {
 	add_filter( 'get_user_metadata', __NAMESPACE__ . '\\hide_welcome_panel', 10, 3 );
 
 	if ( $config['remove-emoji'] ) {
-		remove_emoji();
+		add_action( 'plugins_loaded', __NAMESPACE__ . '\\remove_emoji' );
 	}
 }
 


### PR DESCRIPTION
Currently, the disable emoji feature (#9) is broken, as the `remove_action` calls happen before the `add_action` calls.

This should trigger a 2.0.1 release, as the feature is totally broken. The question is, should we change the default value so that there's no changes when deploying a minor change?