### PR TITLE
Remove maintenance nag from admin notices.

### DIFF
--- a/inc/remove_updates/namespace.php
+++ b/inc/remove_updates/namespace.php
@@ -18,6 +18,7 @@ function bootstrap() {
  * to be nagging users about available updates.
  */
 function remove_update_nag() {
+	remove_action( 'admin_notices', 'maintenance_nag', 10 );
 	remove_filter( 'admin_notices', 'update_nag', 3 );
 	remove_filter( 'network_admin_notices', 'update_nag', 3 );
 	remove_filter( 'update_footer', 'core_update_footer' );


### PR DESCRIPTION
Under normal running conditions this shouldn't be hit due to auto-updates being disabled but is a safety fallback in case something changes in WP Core.