### PR TITLE
Update WP to 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": ">=7.1",
     "stuttter/wp-user-signups": "3.1.0",
-    "johnpbloch/wordpress": "5.2.4",
+    "johnpbloch/wordpress": "5.3.0",
     "altis/cms-installer": "~0.2.1"
   },
   "autoload": {


### PR DESCRIPTION
This is to release a 2.1.0-rc1 release of the CMS module with WP 5.3