### PR TITLE
Disable the admin_email verfication check on login.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -66,6 +66,9 @@ function bootstrap() {
 	if ( $config['remove-emoji'] ) {
 		add_action( 'plugins_loaded', __NAMESPACE__ . '\\remove_emoji' );
 	}
+
+	// Disable the admin_email verification interval.
+	add_filter( 'admin_email_check_interval', '__return_zero' );
 }
 
 /**


### PR DESCRIPTION
We don't have clients using admin_email as we usually set up sites, so we don't want this behaviour. It also gets in the way on local development.