### PR TITLE
Ensure permission check doesnt happen in CLI / early run context

### DIFF
--- a/inc/block_editor/namespace.php
+++ b/inc/block_editor/namespace.php
@@ -58,7 +58,7 @@ function show_wp_block_in_menu( array $args, string $post_type ) {
 		return $args;
 	}
 
-	if ( ! current_user_can( 'edit_posts' ) ) {
+	if ( function_exists( 'wp_get_current_user' ) && ! current_user_can( 'edit_posts' ) ) {
 		return $args;
 	}
 


### PR DESCRIPTION
Fixes a fatal error in CLI runs, missed it as the running app was unaffected.