### PR TITLE
Bootstrap module early

### DIFF
--- a/load.php
+++ b/load.php
@@ -16,4 +16,4 @@ add_action( 'altis.modules.init', function () {
 		'xmlrpc'        => true,
 	];
 	register_module( 'cms', __DIR__, 'CMS', $default_settings, __NAMESPACE__ . '\\bootstrap' );
-} );
+}, 5 );


### PR DESCRIPTION
Other modules may rely on WP_INITIAL_INSTALL so lets make this the first to execute by default.