### PR TITLE
[Backport v2-branch-rc] Update johnpbloch/wordpress requirement from 5.3.1 to 5.3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": ">=7.1",
     "stuttter/wp-user-signups": "3.1.0",
-    "johnpbloch/wordpress": "5.3.1",
+    "johnpbloch/wordpress": "5.3.2",
     "altis/cms-installer": "~0.2.1"
   },
   "autoload": {


### PR DESCRIPTION
Backport #163