### PR TITLE
#99 Set wp_is_large_network to true

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -22,6 +22,12 @@ function bootstrap() {
 		Branding\bootstrap();
 	}
 
+	if ( is_bool( $config['large-network'] ) ) {
+		add_filter( 'wp_is_large_network', function () use ( $config ) {
+			return $config['large-network'];
+		} );
+	}
+
 	if ( $config['login-logo'] ) {
 		add_action( 'login_header', __NAMESPACE__ . '\\add_login_logo' );
 	}

--- a/load.php
+++ b/load.php
@@ -9,6 +9,7 @@ add_action( 'altis.modules.init', function () {
 	$default_settings = [
 		'enabled'       => true,
 		'branding'      => true,
+		'large-network' => true,
 		'login-logo'    => '/vendor/altis/cms/assets/logo.svg',
 		'shared-blocks' => true,
 		'default-theme' => 'base',


### PR DESCRIPTION
Allows `wp_is_large_network` to be controlled via default settings. Can be explicitly set to true or false, or null for WordPress default behaviour. Defaults to true.

See #99