### PR TITLE
#115 Fix Altis spacing in the admin bar

### DIFF
--- a/assets/branding.css
+++ b/assets/branding.css
@@ -1,9 +1,5 @@
-#wp-admin-bar-altis {
+body.wp-admin:not(.folded) #wp-admin-bar-altis {
 	width: 160px;
-}
-
-body.folded #wp-admin-bar-altis {
-	width: auto;
 }
 
 #wp-admin-bar-altis .icon {

--- a/inc/branding/namespace.php
+++ b/inc/branding/namespace.php
@@ -79,7 +79,7 @@ function add_color_scheme() {
  * Enqueue the branding scripts and styles
  */
 function enqueue_admin_scripts() {
-	wp_enqueue_style( 'altis-branding', plugin_dir_url( dirname( __FILE__, 2 ) ) . 'assets/branding.css', [], '2019-04-24-1' );
+	wp_enqueue_style( 'altis-branding', plugin_dir_url( dirname( __FILE__, 2 ) ) . 'assets/branding.css', [], '2020-01-10-1' );
 }
 
 /**


### PR DESCRIPTION
Sets the width of the Altis menu item in the menu bar in the admin only, and when the sidebar is not collapsed (folded). 

Frontend
<img width="330" alt="Screenshot 2020-01-10 at 12 27 39" src="https://user-images.githubusercontent.com/5014023/72153085-c9b5a800-33a4-11ea-89ce-7f4ddf125d51.png">

Admin
<img width="330" alt="Screenshot 2020-01-10 at 12 27 59" src="https://user-images.githubusercontent.com/5014023/72153087-c9b5a800-33a4-11ea-9d65-3e5d75d366c3.png">

Admin - sidebar collapsed
<img width="330" alt="Screenshot 2020-01-10 at 12 28 14" src="https://user-images.githubusercontent.com/5014023/72153090-ca4e3e80-33a4-11ea-9177-ec3119ca13b2.png">

See #115