### PR TITLE
[100] rework signups

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -90,6 +90,10 @@ function bootstrap() {
 
 	// Remove WP-Sign-Ups admin menu.
 	add_action( 'admin_menu', __NAMESPACE__ . '\\remove_wp_signups_admin_menu' );
+
+	// Move the Sign Ups menu into the Users menu.
+	add_action( 'custom_menu_order', __NAMESPACE__ . '\\move_wp_signups_submenu' );
+
 }
 
 /**
@@ -198,6 +202,22 @@ function remove_site_healthcheck_admin_menu() {
  */
 function remove_wp_signups_admin_menu() {
 	remove_menu_page( 'signups' );
+}
+
+/**
+ * Move the Sign Ups list page into the Users menu and rename it to Invitations.
+ */
+function move_wp_signups_submenu() {
+	global $submenu;
+
+	$submenu['signups'][0] = [
+		__( 'Invitations', 'altis' ),
+		'manage_signups',
+		'signups',
+		__( 'Invitations', 'altis' ),
+	];
+
+	$submenu['users.php'][] = $submenu['signups'][0];
 }
 /**
  * Disable access to the site health check admin page.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -94,6 +94,8 @@ function bootstrap() {
 	// Move the Sign Ups menu into the Users menu.
 	add_action( 'custom_menu_order', __NAMESPACE__ . '\\move_wp_signups_submenu' );
 
+	// Change the admin title to Invitations.
+	add_filter( 'admin_title', __NAMESPACE__ . '\\filter_wp_signups_title' );
 }
 
 /**
@@ -219,6 +221,16 @@ function move_wp_signups_submenu() {
 
 	$submenu['users.php'][] = $submenu['signups'][0];
 }
+
+/**
+ * Rename Sign ups to Invitations
+ *
+ * @param string $title The original admin title.
+ */
+function wp_signups_title( $title ) {
+	return str_replace( 'sign ups', __( 'Invitations', 'altis' ), strtolower( $title ) );
+}
+
 /**
  * Disable access to the site health check admin page.
  *

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -87,6 +87,9 @@ function bootstrap() {
 
 	// Force limit comments per page to 50 max.
 	add_filter( 'pre_update_option_comments_per_page', __NAMESPACE__ . '\\set_comments_per_page' );
+
+	// Remove WP-Sign-Ups admin menu.
+	add_action( 'admin_menu', __NAMESPACE__ . '\\remove_wp_signups_admin_menu' );
 }
 
 /**
@@ -190,6 +193,12 @@ function remove_site_healthcheck_admin_menu() {
 	remove_submenu_page( 'tools.php', 'site-health.php' );
 }
 
+/**
+ * Remove the signups menu.
+ */
+function remove_wp_signups_admin_menu() {
+	remove_menu_page( 'signups' );
+}
 /**
  * Disable access to the site health check admin page.
  *


### PR DESCRIPTION
This attempts to remove the "Sign ups" terminology using existing hooks. 

* Sign ups list page moved into the Users menu with the title "Invitations"
* Removes the Sign Ups top level menu
* Hooks into the `admin_title` filter to change "Sign ups" to "Invitations"

**Note:** This does not actually change the title of the page. I was hoping that there would be a WordPress way to change the page title but I wasn't able to get this working in the time I had. 