### PR TITLE
Use more specific class name, better theme compat

### DIFF
--- a/assets/branding.css
+++ b/assets/branding.css
@@ -16,19 +16,22 @@ body.folded #wp-admin-bar-altis {
 	width: auto;
 }
 
-#wp-admin-bar-altis .icon {
+#wp-admin-bar-altis .altis-logo-wrapper {
 	display: block;
 	height: auto;
+	flex: 1;
 }
 
-#wp-admin-bar-altis .icon img {
+#wp-admin-bar-altis .altis-logo-wrapper img {
 	height: 20px;
 	width: auto;
 	margin: 4px 10px 0 3px;
+	display: block;
 }
 
 #wpadminbar #wp-admin-bar-altis-logo .ab-item {
 	padding-top: 2px;
+	display: flex;
 }
 
 /* Hide WordPress version and update button from At a Glance dashboard widget. */

--- a/inc/branding/namespace.php
+++ b/inc/branding/namespace.php
@@ -200,7 +200,7 @@ function admin_bar_menu( WP_Admin_Bar $wp_admin_bar ) {
 	$logo_menu_args = [
 		'href'  => admin_url(),
 		'id'    => 'altis',
-		'title' => '<span class="icon"><img src="' . get_logo_url( 'white' ) . '" /></span>',
+		'title' => '<span class="altis-logo-wrapper"><img src="' . get_logo_url( 'white' ) . '" /></span>',
 	];
 
 	// Set tabindex="0" to make sub menus accessible when no URL is available.


### PR DESCRIPTION
Fixes some img alignment issues in themes that have global styles for images or use the `.icon` CSS class.