### PR TITLE
Fix logo styling and update version string

### DIFF
--- a/assets/branding.css
+++ b/assets/branding.css
@@ -2,7 +2,7 @@ body.wp-admin:not(.folded) #wp-admin-bar-altis {
 	width: 160px;
 }
 
-#wp-admin-bar-altis a {
+#wpadminbar #wp-admin-bar-altis .ab-item {
 	padding: 0 10px;
 }
 
@@ -25,13 +25,16 @@ body.folded #wp-admin-bar-altis {
 #wp-admin-bar-altis .altis-logo-wrapper img {
 	height: 20px;
 	width: auto;
-	margin: 4px 10px 0 3px;
+	margin: 4px 10px 0 0;
 	display: block;
 }
 
-#wpadminbar #wp-admin-bar-altis-logo .ab-item {
-	padding-top: 2px;
+#wpadminbar #wp-admin-bar-altis > .ab-item {
 	display: flex;
+}
+
+#wpadminbar #wp-admin-bar-altis > .ab-item * {
+	word-break: keep-all;
 }
 
 /* Hide WordPress version and update button from At a Glance dashboard widget. */

--- a/inc/branding/namespace.php
+++ b/inc/branding/namespace.php
@@ -113,7 +113,7 @@ function remove_wp_admin_color_schemes() {
  * Enqueue the branding scripts and styles
  */
 function enqueue_admin_scripts() {
-	wp_enqueue_style( 'altis-branding', plugin_dir_url( dirname( __FILE__, 2 ) ) . 'assets/branding.css', [], '2020-02-05-4' );
+	wp_enqueue_style( 'altis-branding', plugin_dir_url( dirname( __FILE__, 2 ) ) . 'assets/branding.css', [], '2020-02-27-1' );
 }
 
 /**


### PR DESCRIPTION
The older versions were kinda confused by the padding changing if the admin bar item was a link or not. I also forgot to update the CSS file version string.