### PR TITLE
Check for table prefix set in ENV in main wp-config.php

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -46,7 +46,7 @@ if ( ! defined( 'WP_INITIAL_INSTALL' ) || ! WP_INITIAL_INSTALL ) {
 }
 
 if ( ! isset( $table_prefix ) ) {
-	$table_prefix = 'wp_';
+	$table_prefix = getenv( 'TABLE_PREFIX' ) ?: 'wp_';
 }
 
 /*


### PR DESCRIPTION
This is done in wp-config-production.php as well so I think it makes sense to ensure this behaviour is always consistent. Also allows us to deprecate wp-config-production.php in future now that there's nothing dynamically generated in there.