### PR TITLE
Load .config/load-early.php as early as possible

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -11,6 +11,11 @@
 // Provide a reference to the app root directory early.
 define( 'Altis\\ROOT_DIR', __DIR__ );
 
+// Load an escape hatch early load file, if it exists.
+if ( file_exists( __DIR__ . '/.config/load-early.php' ) ) {
+	require_once __DIR__ . '/.config/load-early.php';
+}
+
 // Load the plugin API (like add_action etc) early, so everything loaded
 // via the Composer autoloaders can using actions.
 require_once __DIR__ . '/wordpress/wp-includes/plugin.php';


### PR DESCRIPTION
As an escape hatch for things that need to be loaded super early, let's add a load-early config file. (Documentation for this will be in the Docs module rather than here.)