### PR TITLE
Upgrade wp-user-signups to 5.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": ">=7.1",
-    "stuttter/wp-user-signups": "3.1.0",
+    "stuttter/wp-user-signups": "^5.0.0",
     "roots/wp-password-bcrypt": "1.0.0",
     "johnpbloch/wordpress": "5.3.2",
     "altis/cms-installer": "^0.4.1",


### PR DESCRIPTION
Turns out there was no packages published to packagist since 2017. This brings us up to the latest, which includes support for php 7.3+ (see https://github.com/humanmade/platform-dev/issues/511)

Changelog:

* PHP 7.3 support
* Rename text domain back to match WordPress.org plugin slug

* Database schema update

Specifically see https://github.com/stuttter/wp-user-signups/commit/ad77b22ee0b5b1156f114f0cab24cac5963ad1d1 on the schema switch. The upgrade routine should automatically be applied.