### PR TITLE
Change the WP 5.4 default block editor settings

### DIFF
--- a/assets/editor-settings.js
+++ b/assets/editor-settings.js
@@ -6,8 +6,8 @@
 	}
 
 	// Get user ID from utils localization data.
-	var settingsKey = 'WP_DATA_USER_' + altisDefaultEditorSettings.uid;
-	var settings = JSON.parse( localStorage.getItem( settingsKey ) || '{}' );
+	const settingsKey = 'WP_DATA_USER_' + window.altisDefaultEditorSettings.uid;
+	let settings = JSON.parse( localStorage.getItem( settingsKey ) || '{}' );
 
 	// If this isn't an object then bail.
 	if ( typeof settings !== 'object' ) {

--- a/assets/editor-settings.js
+++ b/assets/editor-settings.js
@@ -1,0 +1,47 @@
+( function () {
+
+	// Check for existence os localStorage WP User Settings.
+	if ( ! window.localStorage ) {
+		return;
+	}
+
+	// Get user ID from utils localization data.
+	var settingsKey = 'WP_DATA_USER_' + altisDefaultEditorSettings.uid;
+	var settings = JSON.parse( localStorage.getItem( settingsKey ) || '{}' );
+
+	// If this isn't an object then bail.
+	if ( typeof settings !== 'object' ) {
+		return;
+	}
+
+	// Update the setting with our desired defaults.
+	function updateSettings() {
+		localStorage.setItem( settingsKey, JSON.stringify( settings ) );
+	}
+
+	if ( settings['core/edit-post'] ) {
+		// If there are already settings then check if the settings with bad defaults are present.
+		if ( settings['core/edit-post']['preferences'] && settings['core/edit-post']['preferences']['features'] ) {
+			if ( typeof settings['core/edit-post']['preferences']['features']['fullscreenMode'] === 'undefined' ) {
+				settings['core/edit-post']['preferences']['features']['fullscreenMode'] = false;
+				updateSettings();
+			}
+			if ( typeof settings['core/edit-post']['preferences']['features']['welcomeGuide'] === 'undefined' ) {
+				settings['core/edit-post']['preferences']['features']['welcomeGuide'] = false;
+				updateSettings();
+			}
+		}
+	} else {
+		// Set our own good defaults.
+		settings['core/edit-post'] = {
+			preferences: {
+				features: {
+					fullscreenMode: false,
+					welcomeGuide: false,
+				},
+			},
+		};
+		updateSettings();
+	}
+
+} )();

--- a/inc/block_editor/namespace.php
+++ b/inc/block_editor/namespace.php
@@ -9,6 +9,7 @@ function bootstrap() {
 	add_action( 'init', __NAMESPACE__ . '\\register_block_categories' );
 	add_action( 'admin_menu', __NAMESPACE__ . '\\admin_menu', 9 );
 	add_filter( 'register_post_type_args', __NAMESPACE__ . '\\show_wp_block_in_menu', 10, 2 );
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\set_default_editor_preferences' );
 }
 
 /**
@@ -128,4 +129,31 @@ function admin_menu() {
 
 		$submenu[ $ptype_file ][ $i++ ] = [ esc_attr( $tax->labels->menu_name ), $tax->cap->manage_terms, sprintf( $edit_tags_file, $tax->name ) ];
 	}
+}
+
+/**
+ * Queue scripts for setting default block editor preferences in WP 5.4.
+ *
+ * Disables default fullscreen mode and welcome guide.
+ */
+function set_default_editor_preferences() {
+	global $wp_scripts;
+
+	wp_register_script(
+		'altis-default-editor-settings',
+		plugin_dir_url( dirname( __FILE__, 2 ) ) . 'assets/editor-settings.js',
+		[],
+		'2020-06-04-1',
+		false
+	);
+	wp_localize_script(
+		'altis-default-editor-settings',
+		'altisDefaultEditorSettings',
+		[
+			'uid' => get_current_user_id(),
+		]
+	);
+
+	// Add default settings as a dependency of wp-data.
+	$wp_scripts->registered['wp-data']->deps[] = 'altis-default-editor-settings';
 }


### PR DESCRIPTION
In WP 5.4 the block editor will by default open in full screen mode with the welcome guide showing.

This update sets both of those defaults to false and allows for persisting settings users have opted in to.