### PR TITLE
Hide healthcheck dashboard widget

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -57,8 +57,11 @@ function bootstrap() {
 
 	add_filter( 'pre_site_option_fileupload_maxk', __NAMESPACE__ . '\\override_fileupload_maxk_option' );
 	add_filter( 'wp_fatal_error_handler_enabled', __NAMESPACE__ . '\\filter_wp_fatal_handler' );
+
+	// Hide Healthcheck UI.
 	add_action( 'admin_menu', __NAMESPACE__ . '\\remove_site_healthcheck_admin_menu' );
 	add_action( 'admin_init', __NAMESPACE__ . '\\disable_site_healthcheck_access' );
+	add_action( 'wp_dashboard_setup', __NAMESPACE__ . '\\remove_site_healthcheck_dashboard_widget' );
 
 	add_filter( 'login_headerurl', __NAMESPACE__ . '\\login_header_url' );
 
@@ -215,6 +218,15 @@ function disable_site_healthcheck_access() {
 	}
 
 	wp_die( 'Site Health not accessible.' );
+}
+
+/**
+ * Remove the healthcheck dashboard widget.
+ *
+ * @return void
+ */
+function remove_site_healthcheck_dashboard_widget() {
+	remove_meta_box( 'dashboard_site_health', 'dashboard', 'normal' );
 }
 
 /**


### PR DESCRIPTION
WP 5.4 introduces a new dashboard widget with the site healthcheck, because we use custom healthchecks this is misleading for Altis so we need to remove it by default.