### PR TITLE
Bump the admin theme CSS version

### DIFF
--- a/inc/branding/namespace.php
+++ b/inc/branding/namespace.php
@@ -124,7 +124,7 @@ function enqueue_admin_scripts() {
 	// scheme to maintain cascade specificity.
 	$wp_styles->registered['colors']->deps[] = 'wp-components';
 
-	wp_enqueue_style( 'altis-branding', plugin_dir_url( dirname( __FILE__, 2 ) ) . 'assets/branding.css', [], '2020-02-27-1' );
+	wp_enqueue_style( 'altis-branding', plugin_dir_url( dirname( __FILE__, 2 ) ) . 'assets/branding.css', [], '2020-06-22-1' );
 }
 
 /**


### PR DESCRIPTION
I forgot to do this in the previous PR updating the styles. We need to ensure the latest version is downloaded when this goes to production environments with a long cache time out.