### PR TITLE
Add autoloader flag to command

### DIFF
--- a/.build-script
+++ b/.build-script
@@ -5,7 +5,7 @@
 #====================#
 
 # Install composer dependencies
-composer install --no-dev --optimize-autoloader
+composer install --no-dev --optimize-autoloader --apcu-autoloader
 
 # Edit below this line to add any additional build steps.
 #


### PR DESCRIPTION
Fixes https://github.com/humanmade/altis-cms/issues/168

@joehoyle I'm not clear on how to test the second acceptance criteria. Do you mean run the command locally with that parameter? `composer create-project altis/skeleton altis-test --apcu-autoloader`