### PR TITLE
Override sites list for better detail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
       "inc/permalinks/namespace.php",
       "inc/add_site_ui/namespace.php",
       "inc/cli/namespace.php",
+      "inc/network_ui/namespace.php",
       "inc/real_guids/namespace.php"
     ],
     "classmap": [

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -25,6 +25,7 @@ function bootstrap() {
 	Remove_Updates\bootstrap();
 	Permalinks\bootstrap();
 	Add_Site_UI\bootstrap();
+	Network_UI\bootstrap();
 	Real_GUIDs\bootstrap();
 
 	if ( $config['branding'] ) {

--- a/inc/network_ui/namespace.php
+++ b/inc/network_ui/namespace.php
@@ -107,7 +107,7 @@ function render_name_column( $id ) : void {
 	printf(
 		'<strong class="altis-site-name"><a href="%s" class="edit" title="%s">%s</a></strong>',
 		esc_url( get_admin_url( $id ) ),
-		__( 'Open site dashboard', 'altis' ),
+		esc_html__( 'Open site dashboard', 'altis' ),
 		esc_html( $name )
 	);
 	printf(
@@ -120,7 +120,7 @@ function render_name_column( $id ) : void {
 	if ( 'list' !== $mode ) {
 		printf(
 			'<p><em>%s</em></p>',
-			$desc
+			esc_html( $desc )
 		);
 	}
 }
@@ -132,7 +132,7 @@ function render_name_column( $id ) : void {
  * @return void Outputs directly.
  */
 function render_site_states( WP_Site $site ) : void {
-	$site_states = array();
+	$site_states = [];
 	$wp_list_table = _get_list_table( 'WP_MS_Sites_List_Table' );
 
 	if ( is_main_site( $site->id ) ) {
@@ -168,8 +168,11 @@ function render_site_states( WP_Site $site ) : void {
 		echo ' <em>(';
 		foreach ( $site_states as $state ) {
 			++$i;
-			( $i == $state_count ) ? $sep = '' : $sep = ', ';
-			echo "<span class='post-state'>{$state}{$sep}</span>";
+			printf(
+				'<span class="post-state">%s%s</span>',
+				esc_html( $state ),
+				$i === $state_count ? '' : ', '
+			);
 		}
 		echo ')</em>';
 	}

--- a/inc/network_ui/namespace.php
+++ b/inc/network_ui/namespace.php
@@ -20,7 +20,7 @@ function bootstrap() {
  * @return array
  */
 function get_config() : array {
-	return Altis\get_config()['modules']['cms']['network_ui'];
+	return Altis\get_config()['modules']['cms']['network-ui'];
 }
 
 /**
@@ -75,7 +75,7 @@ function change_row_actions( array $actions, $id ) {
 	$site = get_site( $id );
 
 	// Hide "Spam", unless the site is marked as spam (i.e. action is "Not Spam")
-	if ( $config['disable_spam'] && ! $site->spam ) {
+	if ( $config['disable-spam'] && ! $site->spam ) {
 		unset( $actions['spam'] );
 	}
 	return $actions;

--- a/inc/network_ui/namespace.php
+++ b/inc/network_ui/namespace.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Altis\CMS\Network_UI;
+
+use Altis;
+use WP_Site;
+
+/**
+ * Bootstrap.
+ */
+function bootstrap() {
+	add_filter( 'wpmu_blogs_columns', __NAMESPACE__ . '\\override_columns' );
+	add_filter( 'manage_sites_custom_column', __NAMESPACE__ . '\\handle_column', 10, 2 );
+	add_filter( 'manage_sites_action_links', __NAMESPACE__ . '\\change_row_actions', 0, 2 );
+}
+
+/**
+ * Get configuration for the network UI.
+ *
+ * @return array
+ */
+function get_config() : array {
+	return Altis\get_config()['modules']['cms']['network_ui'];
+}
+
+/**
+ * Override the columns in the site list.
+ *
+ * @param array $columns Columns provided by WordPress.
+ * @return array Overridden columns.
+ */
+function override_columns( array $columns ) : array {
+	$before = array_slice( $columns, 0, 1 );
+	$extra = [
+		'altis_name' => 'Name',
+	];
+	$after = array_slice( $columns, 2 );
+	return array_merge( $before, $extra, $after );
+}
+
+/**
+ * Handle rendering a column.
+ *
+ * Handles any custom columns we have.
+ *
+ * @param string $column Column ID to render.
+ * @param string|int $id Site ID being rendered.
+ */
+function handle_column( string $column, $id ) : void {
+	if ( $column === 'altis_name' ) {
+		render_name_column( $id );
+	}
+}
+
+/**
+ * Change row actions.
+ *
+ * WordPress convention is that the first action in the row actions matches the
+ * action of the title, so we need to move Dashboard to the first position.
+ *
+ * Also hides unwanted actions per config.
+ *
+ * @param array $actions Actions to render.
+ * @param string|int $id Site ID being rendered.
+ * @return array Overridden actions.
+ */
+function change_row_actions( array $actions, $id ) {
+	$prefix = [
+		'backend' => $actions['backend'],
+	];
+	unset( $actions['backend'] );
+	$actions = array_merge( $prefix, $actions );
+
+	$config = get_config();
+	$site = get_site( $id );
+
+	// Hide "Spam", unless the site is marked as spam (i.e. action is "Not Spam")
+	if ( $config['disable_spam'] && ! $site->spam ) {
+		unset( $actions['spam'] );
+	}
+	return $actions;
+}
+
+/**
+ * Render the Name column.
+ *
+ * @param string|int $id Site ID being rendered.
+ * @return void Outputs directly.
+ */
+function render_name_column( $id ) : void {
+	global $mode;
+	$blog = get_site( $id );
+
+	$shorturl = untrailingslashit( $blog->domain . $blog->path );
+	if ( $blog->path !== '/' ) {
+		$shorturl = trailingslashit( $shorturl );
+	}
+
+	// Gather information.
+	switch_to_blog( $blog->id );
+	$name = get_option( 'blogname' );
+	// $edit = ...;
+	if ( $mode !== 'list' ) {
+		$desc = get_option( 'blogdescription' );
+	}
+	restore_current_blog();
+
+	printf(
+		'<strong class="altis-site-name"><a href="%s" class="edit" title="%s">%s</a></strong>',
+		esc_url( get_admin_url( $id ) ),
+		__( 'Open site dashboard', 'altis' ),
+		esc_html( $name )
+	);
+	printf(
+		' &mdash; <span class="altis-site-shorturl">%s</span>',
+		esc_html( $shorturl )
+	);
+
+	render_site_states( $blog );
+
+	if ( 'list' !== $mode ) {
+		printf(
+			'<p><em>%s</em></p>',
+			$desc
+		);
+	}
+}
+
+function render_site_states( WP_Site $site ) {
+	$site_states = array();
+	$wp_list_table = _get_list_table( 'WP_MS_Sites_List_Table' );
+
+	// $site is still an array, so get the object.
+	$_site = $site;
+
+	if ( is_main_site( $site->id ) ) {
+		$site_states['main'] = __( 'Primary site', 'altis' );
+	}
+	if ( ! $site->public ) {
+		$site_states['private'] = __( 'Private', 'altis' );
+	}
+
+	reset( $wp_list_table->status_list );
+
+	$site_status = isset( $_REQUEST['status'] ) ? wp_unslash( trim( $_REQUEST['status'] ) ) : '';
+	foreach ( $wp_list_table->status_list as $status => $col ) {
+		if ( ( 1 === intval( $site->{$status} ) ) && ( $site_status !== $status ) ) {
+			$site_states[ $col[0] ] = $col[1];
+		}
+	}
+
+	/**
+	 * Filter the default site display states for items in the Sites list table.
+	 *
+	 * @since 5.3.0
+	 *
+	 * @param array $site_states An array of site states. Default 'Main',
+	 *                           'Archived', 'Mature', 'Spam', 'Deleted'.
+	 * @param WP_Site $site The current site object.
+	 */
+	$site_states = apply_filters( 'display_site_states', $site_states, $site );
+
+	if ( ! empty( $site_states ) ) {
+		$state_count = count( $site_states );
+		$i           = 0;
+		echo ' <em>(';
+		foreach ( $site_states as $state ) {
+			++$i;
+			( $i == $state_count ) ? $sep = '' : $sep = ', ';
+			echo "<span class='post-state'>{$state}{$sep}</span>";
+		}
+		echo ')</em>';
+	}
+}

--- a/inc/network_ui/namespace.php
+++ b/inc/network_ui/namespace.php
@@ -125,7 +125,13 @@ function render_name_column( $id ) : void {
 	}
 }
 
-function render_site_states( WP_Site $site ) {
+/**
+ * Render the states of a site in the table.
+ *
+ * @param WP_Site $site Site being rendered.
+ * @return void Outputs directly.
+ */
+function render_site_states( WP_Site $site ) : void {
 	$site_states = array();
 	$wp_list_table = _get_list_table( 'WP_MS_Sites_List_Table' );
 

--- a/inc/network_ui/namespace.php
+++ b/inc/network_ui/namespace.php
@@ -99,7 +99,6 @@ function render_name_column( $id ) : void {
 	// Gather information.
 	switch_to_blog( $blog->id );
 	$name = get_option( 'blogname' );
-	// $edit = ...;
 	if ( $mode !== 'list' ) {
 		$desc = get_option( 'blogdescription' );
 	}
@@ -129,9 +128,6 @@ function render_name_column( $id ) : void {
 function render_site_states( WP_Site $site ) {
 	$site_states = array();
 	$wp_list_table = _get_list_table( 'WP_MS_Sites_List_Table' );
-
-	// $site is still an array, so get the object.
-	$_site = $site;
 
 	if ( is_main_site( $site->id ) ) {
 		$site_states['main'] = __( 'Primary site', 'altis' );

--- a/load.php
+++ b/load.php
@@ -22,8 +22,8 @@ add_action( 'altis.modules.init', function () {
 		'xmlrpc'        => true,
 		'feeds'         => true,
 		'cloner'        => true,
-		'network_ui'    => [
-			'disable_spam' => true,
+		'network-ui'    => [
+			'disable-spam' => true,
 		],
 	];
 	Altis\register_module( 'cms', __DIR__, 'CMS', $default_settings, __NAMESPACE__ . '\\bootstrap' );

--- a/load.php
+++ b/load.php
@@ -21,6 +21,9 @@ add_action( 'altis.modules.init', function () {
 		'remove-emoji'  => true,
 		'xmlrpc'        => true,
 		'feeds'         => true,
+		'network_ui'    => [
+			'disable_spam' => true,
+		],
 	];
 	Altis\register_module( 'cms', __DIR__, 'CMS', $default_settings, __NAMESPACE__ . '\\bootstrap' );
 }, 5 );


### PR DESCRIPTION
The sites list has an unclear visual hierarchy, and highlights less relevant details for most users.

This PR changes the site list to have site names as the primary entry instead of the URL, and de-emphasises less-important information. Additionally, it hides the rarely-used Spam action primarily used for WordPress.com-style open-registration multisites.

Before | After
-- | --
![Screenshot_2020-07-24 Sites ‹ Network Admin Altis Demo — Altis(3)](https://user-images.githubusercontent.com/21655/88409484-ec516080-cdcc-11ea-80d0-5fc0f1956307.png) | ![Screenshot_2020-07-24 Sites ‹ Network Admin Altis Demo — Altis(2)](https://user-images.githubusercontent.com/21655/88409498-ef4c5100-cdcc-11ea-8ebb-b93acf71d575.png)

Still needs docs for the additional setting.