### PR TITLE
Add set -e to build script

### DIFF
--- a/.build-script
+++ b/.build-script
@@ -4,6 +4,9 @@
 # Altis Build Script #
 #====================#
 
+# Ensure build script fails if any steps return a non-zero exit code.
+set -e
+
 # Install composer dependencies
 composer install --no-dev --optimize-autoloader --apcu-autoloader
 

--- a/.build-script
+++ b/.build-script
@@ -1,11 +1,8 @@
-#!/bin/bash
+#!/bin/bash -e
 
 #====================#
 # Altis Build Script #
 #====================#
-
-# Ensure build script fails if any steps return a non-zero exit code.
-set -e
 
 # Install composer dependencies
 composer install --no-dev --optimize-autoloader --apcu-autoloader


### PR DESCRIPTION
Deploys can still try and go ahead even if a build step fails. This will make sure that doesn't happen.

Fixes #262 