### PR TITLE
Fix headings in docs/helper-functions.md

### DIFF
--- a/docs/helper-functions.md
+++ b/docs/helper-functions.md
@@ -1,6 +1,6 @@
-## Helper Functions
+# Helper Functions
 
-### `clean_html( string $text, array $allowedtags = [], string $context = '' ) : string`
+## `clean_html( string $text, array $allowedtags = [], string $context = '' ) : string`
 
 When translating strings in WordPress, the most common functions to use are `__()` (translate and return) or `_e()` (translate and output). Where possible, these need to be escaped too, to ensure that translations don't accidentally break your output. For this reason, `esc_html_e()`, `esc_attr_e()`, etc are offered by WordPress as convenience functions.
 
@@ -8,7 +8,7 @@ However, this falls down when you need to have HTML in the translation.
 
 This function provides a nice, easy, performant way to perform sanitization on translated strings. Rather than requiring you to work with the internals of kses, it's much closer to functions like `esc_html()`.
 
-#### Parameters
+### Parameters
 
 **`$text`**
 
@@ -22,10 +22,10 @@ _(array)_ Allowed tags, see examples.
 
 _(string)_ kses context to use (see [wp_kses_allowed_html](http://developer.wordpress.org/reference/functions/wp_kses_allowed_html/))
 
-#### Return
+### Return
 _(string)_ Escaped string for output into HTML context.
 
-#### Example usage
+### Example usage
 
 For the most part, `clean_html()` can be used in exactly the same way developers are used to using other escaping functions.
 
@@ -69,11 +69,11 @@ $text = clean_html(
 );
 ```
 
-### `print_clean_html( string $text, array $allowedtags = [], string $context = '' ) : void`
+## `print_clean_html( string $text, array $allowedtags = [], string $context = '' ) : void`
 
 Equivalent of `clean_html()` which echoes output directly rather than returning.
 
-#### Parameters
+### Parameters
 
 **`$text`**
 
@@ -87,25 +87,25 @@ _(array)_ Allowed tags, see examples under `clean_html`.
 
 _(string)_ kses context to use (see [wp_kses_allowed_html](http://developer.wordpress.org/reference/functions/wp_kses_allowed_html/))
 
-#### Return
+### Return
 _(void)_ Escaped string is echoed to the browser directly.
 
-### `wp_hash_password( string $password )`
+## `wp_hash_password( string $password )`
 
 Hash password using bcrypt. This function calls `password_hash` instead of WP's default password hasher.
 
 The `wp_hash_password_options` filter is available to set the [options](http://php.net/manual/en/function.password-hash.php) that `password_hash` can accept.
 
-#### Parameters
+### Parameters
 
 **`$password`**
 
 _(string)(required)_ Plaintext password
 
-#### Return
+### Return
 _(bool|string)_
 
-### `wp_check_password( string $password, string $hash, int|string $userId )`
+## `wp_check_password( string $password, string $hash, int|string $userId )`
 
 Check if user has entered correct password, supports bcrypt and pHash.
 
@@ -114,7 +114,7 @@ However, it also checks if a user's password was *previously* hashed with the ol
 
 The `check_password` filter is available just like the default WP function.
 
-#### Parameters
+### Parameters
 
 **`$password`**
 
@@ -128,16 +128,16 @@ _(string)(required)_ Hash of password
 
 _(int|string)_ ID of user to whom the password belongs
 
-#### Return
+### Return
 _(mixed|void)_
 
-### `wp_set_password( string $password, int $userId )`
+## `wp_set_password( string $password, int $userId )`
 
 Set password using bcrypt.
 
 This function is included here verbatim but with the addition of returning the hash. The default WP function does not return anything which means you end up hashing it twice for no reason.
 
-#### Parameters
+### Parameters
 
 **`$password`**
 _(string)(required)_ Plaintext password
@@ -145,5 +145,5 @@ _(string)(required)_ Plaintext password
 **`$userId`**
 _(int)(required)_ ID of user to whom password belongs
 
-#### Return
+### Return
 _(bool|string)_


### PR DESCRIPTION
Headings should start with `h1`.

Fixes #253 