### PR TITLE
set AUTOMATIC_UPDATER_DISABLED to true to disable auto updates

### DIFF
--- a/inc/remove_updates/namespace.php
+++ b/inc/remove_updates/namespace.php
@@ -48,7 +48,7 @@ function remove_update_nag() {
  * Remove all automatic updates.
  */
 function remove_auto_updates() {
-	define( 'AUTOMATIC_UPDATER_DISABLED', false );
+	define( 'AUTOMATIC_UPDATER_DISABLED', true );
 }
 
 /**


### PR DESCRIPTION
WordPress' automatic updater expects this constant to return true if auto updates are to be disabled:

https://github.com/WordPress/WordPress/blob/9da0a44b3e70117089257777cc38a3305a6c6c77/wp-admin/includes/class-wp-automatic-updater.php#L41