### PR TITLE
Don't fatal on null value in real_url_path()

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -345,13 +345,18 @@ function set_comments_per_page( $value ) : int {
 /**
  * Ensure URLs do not contain any relative paths.
  *
- * @param string $url The dependency URL.
+ * @param string|null $url The dependency URL.
  * @param string $handle The dependency handle.
- * @return string
+ * @return string|null
  */
-function real_url_path( string $url, string $handle ) : string {
+function real_url_path( ?string $url, string $handle ) : ?string {
 	global $wp_scripts, $wp_styles;
-
+	
+	// Avoid odd behaviour if null or empty value is passed.
+	if ( empty( $url ) ) {
+		return $url;
+	}
+ 
 	// Skip if there are no /./ or /../ patterns.
 	if ( strpos( $url, '/.' ) === false ) {
 		return $url;


### PR DESCRIPTION
In some cases `$url` might be `null` when passed to `real_url_path()`. Ideally WP should warn about this so any error output should be handled upstream.

Fixes #296 