### PR TITLE
Add packages to install-overrides

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,12 @@
     ]
   },
   "extra": {
-    "altis": {}
+    "altis": {
+      "install-overrides": [
+        "humanmade/post-cloner",
+        "roots/wp-password-bcrypt",
+        "stuttter/wp-user-signups"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Adds WP packages which need their installation path overridden to the config.

See https://github.com/humanmade/altis-core/pull/120.