### PR TITLE
Fix network admin confirm site action forms

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -89,6 +89,9 @@ function bootstrap() {
 		WP_CLI::add_hook( 'after_invoke:core multisite-install', __NAMESPACE__ . '\\setup_user_signups_on_install' );
 	}
 
+	// Fix network admin site actions.
+	add_filter( 'network_admin_url', __NAMESPACE__ . '\\fix_network_action_confirmation' );
+
 	// Don't show the welcome panel.
 	add_filter( 'get_user_metadata', __NAMESPACE__ . '\\hide_welcome_panel', 10, 3 );
 
@@ -122,6 +125,24 @@ function bootstrap() {
 
 	// Fix redirect canonical redirecting on equivalent query strings.
 	add_filter( 'redirect_canonical', __NAMESPACE__ . '\\maybe_redirect', 11, 2 );
+}
+
+/**
+ * Adds `_wp_http_referer` to confirm action links the in network admin.
+ *
+ * @see https://core.trac.wordpress.org/ticket/52378
+ *
+ * @param string $url The complete network admin URL including scheme and path.
+ * @return string The complete network admin URL including scheme and path.
+ */
+function fix_network_action_confirmation( string $url ) : string {
+	parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $params );
+	if ( isset( $params['action'] ) && $params['action'] === 'confirm' ) {
+		$url = add_query_arg( [
+			'_wp_http_referer' => urlencode( wp_unslash( $_SERVER['REQUEST_URI'] ) ),
+		], $url );
+	}
+	return $url;
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -128,7 +128,7 @@ function bootstrap() {
 }
 
 /**
- * Adds `_wp_http_referer` to confirm action links the in network admin.
+ * Adds `_wp_http_referer` to confirm action links in the network admin.
  *
  * @see https://core.trac.wordpress.org/ticket/52378
  *


### PR DESCRIPTION
In the network admin sites list there are links to perform certain actions like archive/deactivate/delete and so on. Because the referer header is not available in cloud environments the interstitial confirmation forms get an empty value for the `_wp_htt_referer` field resulting in an expired link error page on confirmation.

This adds the referer as a query string argument to any network admin URLs with the `confirm` action so that the referer can be read from there instead.

Fixes #295