### PR TITLE
Better sanitization and validation for subdomains, subdirectories and new site URLs

### DIFF
--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -213,6 +213,22 @@ function sanitize_domain_segment( string $segment ) : string {
 }
 
 /**
+ * Encode a URL string with the IDNA encoder
+ *
+ * @see https://developer.wordpress.org/reference/classes/requests_idnaencoder/
+ * @see https://tools.ietf.org/html/rfc3490
+ *
+ * @uses https://developer.wordpress.org/reference/classes/requests_idnaencoder/encode/
+ *
+ * @param string $url A URL domain string to encode.
+ *
+ * @return string The encoded string.
+ */
+function idna_encode( string $url ) : string {
+	return Requests_IDNAEncoder::encode( $url );
+}
+
+/**
  * Validate a domain name.
  *
  * Checks that the domain name has 2+ valid DNS segments.

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -441,7 +441,7 @@ function handle_subdirectory( string $value ) : ?array {
 	$network_host = $network_url['host'];
 
 	// Break out URL query parameters and hashes.
-	$path = trim( preg_split( "/(&+|\?+|#+)/", $value )[0], '/' );
+	$path = trim( preg_split( '/(&+|\?+|#+)/', $value )[0], '/' );
 
 	return [
 		'domain' => $network_host,

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -305,7 +305,7 @@ function add_site_form_handler() {
 		$site_type = 'site-subdomain';
 	}
 
-	$value = sanitize_text_field( wp_unslash( $_POST['url'] ) ?? '' );
+	$value = sanitize_text_field( wp_unslash( $_POST['url'] ?? '' ) );
 	$title = sanitize_text_field( wp_unslash( $_POST['title'] ?? '' ) );
 
 	if ( empty( $value ) || empty( $title ) ) {

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -203,7 +203,6 @@ function validate_domain_segment( string $segment ) : bool {
  */
 function sanitize_domain_segment( string $segment ) : string {
 	$segment = wp_kses_no_null( $segment );
-	$segment = remove_accents( $segment );
 
 	if ( strlen( $segment ) < 1 ) {
 		return '';

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -202,7 +202,6 @@ function validate_domain_segment( string $segment ) : bool {
 function sanitize_domain_segment( string $segment ) : string {
 	$segment = wp_kses_no_null( $segment );
 	$segment = remove_accents( $segment );
-	$segment = sanitize_title_with_dashes( $segment, null, 'save' );
 
 	if ( strlen( $segment ) < 1 ) {
 		return '';

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -278,7 +278,7 @@ function add_site_form_handler() {
 		$site_type = 'site-subdomain';
 	}
 
-	$value = sanitize_text_field( wp_unslash( $_POST['url'] ?? '' ) );
+	$value = sanitize_title( sanitize_text_field( wp_unslash( $_POST['url'] ?? '' ) ) );
 	$title = sanitize_text_field( wp_unslash( $_POST['title'] ?? '' ) );
 
 	if ( empty( $value ) || empty( $title ) ) {

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -257,9 +257,6 @@ function validate_path( $path ) {
 		return true;
 	}
 
-	// Break out URL query parameters and hashes.
-	$path = preg_split( "/(&+|\?+|#+)/", $path )[0];
-
 	$illegal_names = get_site_option( 'illegal_names' );
 	if ( empty( $illegal_names ) ) {
 		$illegal_names = [];
@@ -445,7 +442,8 @@ function handle_subdirectory( string $value ) : ?array {
 	$network_url = wp_parse_url( network_site_url() );
 	$network_host = $network_url['host'];
 
-	$path = trim( $value, '/' );
+	// Break out URL query parameters and hashes.
+	$path = trim( preg_split( "/(&+|\?+|#+)/", $value )[0], '/' );
 
 	return [
 		'domain' => $network_host,

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -442,7 +442,7 @@ function handle_subdomain( string $value ) : ?array {
 	$value = sanitize_domain_segment( $value );
 
 	return [
-		'domain' => $value . '.' . $network_host,
+		'domain' => idna_encode( $value . '.' . $network_host ),
 		'path' => '/',
 	];
 }
@@ -461,7 +461,7 @@ function handle_subdirectory( string $value ) : ?array {
 	$path = trim( preg_split( '/(&+|\?+|#+)/', $value )[0], '/' );
 
 	return [
-		'domain' => $network_host,
+		'domain' => idna_encode( $network_host ),
 		'path' => $path,
 	];
 }
@@ -505,7 +505,7 @@ function handle_custom_domain( string $url ) : ?array {
 	$path = trim( $url_array['path'], '/' );
 
 	return [
-		'domain' => $domain,
+		'domain' => idna_encode( $domain ),
 		'path' => '/' . $path,
 	];
 }

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -462,7 +462,7 @@ function handle_subdirectory( string $value ) : ?array {
 
 	return [
 		'domain' => idna_encode( $network_host ),
-		'path' => $path,
+		'path' => urlencode( $path ),
 	];
 }
 
@@ -506,6 +506,6 @@ function handle_custom_domain( string $url ) : ?array {
 
 	return [
 		'domain' => idna_encode( $domain ),
-		'path' => '/' . $path,
+		'path' => '/' . urlencode( $path ),
 	];
 }

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -186,6 +186,7 @@ function output_add_site_page() {
  * @return bool True if valid, false otherwise.
  */
 function validate_domain_segment( string $segment ) : bool {
+	$segment = sanitize_domain_segment( $segment ); //var_dump( 'segment:', $segment );
 	return (bool) preg_match( '/^' . REGEX_DOMAIN_SEGMENT . '$/', $segment );
 }
 
@@ -422,6 +423,8 @@ function handle_subdomain( string $value ) : ?array {
 	if ( in_array( $value, $illegal_names, true ) ) {
 		return null;
 	}
+
+	$value = sanitize_domain_segment( $value );
 
 	return [
 		'domain' => $value . '.' . $network_host,

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -199,17 +199,6 @@ function sanitize_domain_segment( string $segment ) : string {
 		return '';
 	}
 
-	$segment = trim_segment_length( $segment );
-
-	return $segment;
-}
-
-function trim_segment_length( string $segment, int $length = 63 ) : string {
-	if ( strlen( $segment ) > $length ) {
-		$segment = substr( $segment, 0, $length );
-		$segment = rtrim( $segment, '-' );
-	}
-
 	return $segment;
 }
 

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -188,7 +188,6 @@ function output_add_site_page() {
  * @return bool True if valid, false otherwise.
  */
 function validate_domain_segment( string $segment ) : bool {
-	$segment = sanitize_domain_segment( $segment );
 	return (bool) preg_match( '/^' . REGEX_DOMAIN_SEGMENT . '$/', $segment );
 }
 

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -15,6 +15,18 @@ const REGEX_DOMAIN_SEGMENT = '(?![0-9]+$)(?!.*-$)(?!-)[a-zA-Z0-9-]{1,63}';
 function bootstrap() {
 	add_action( 'admin_init', __NAMESPACE__ . '\\add_site_form_handler' );
 	add_action( 'load-site-new.php', __NAMESPACE__ . '\\output_add_site_page', 1000 );
+	add_filter( 'site_by_path_segments_count', __NAMESPACE__ . '\\filter_segments_count' );
+}
+
+/**
+ * Override the default segments count.
+ *
+ * Arbitrarily allowing 4 URL segments.
+ *
+ * @return int The number of valid segments.
+ */
+function filter_segments_count() : int {
+	return 4;
 }
 
 /**

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -192,25 +192,6 @@ function validate_domain_segment( string $segment ) : bool {
 }
 
 /**
- * Sanitize a domain segment.
- *
- * Strips out invalid characters from a URL segment.
- *
- * @param string $segment Dirty segment to sanitize.
- *
- * @return string The cleaned segment.
- */
-function sanitize_domain_segment( string $segment ) : string {
-	$segment = wp_kses_no_null( $segment );
-
-	if ( strlen( $segment ) < 1 ) {
-		return '';
-	}
-
-	return $segment;
-}
-
-/**
  * Encode a URL string with the IDNA encoder
  *
  * @see https://developer.wordpress.org/reference/classes/requests_idnaencoder/
@@ -437,7 +418,7 @@ function handle_subdomain( string $value ) : ?array {
 		return null;
 	}
 
-	$value = sanitize_domain_segment( $value );
+	$value = wp_kses_no_null( $value );
 
 	return [
 		'domain' => idna_encode( $value . '.' . $network_host ),

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -257,6 +257,9 @@ function validate_path( $path ) {
 		return true;
 	}
 
+	// Break out URL query parameters and hashes.
+	$path = preg_split( "/(&+|\?+|#+)/", $path )[0];
+
 	$illegal_names = get_site_option( 'illegal_names' );
 	if ( empty( $illegal_names ) ) {
 		$illegal_names = [];

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -283,7 +283,7 @@ function add_site_form_handler() {
 		$site_type = 'site-subdomain';
 	}
 
-	$value = sanitize_title( sanitize_text_field( wp_unslash( $_POST['url'] ?? '' ) ) );
+	$value = sanitize_text_field( wp_unslash( $_POST['url'] ) ?? '' );
 	$title = sanitize_text_field( wp_unslash( $_POST['title'] ?? '' ) );
 
 	if ( empty( $value ) || empty( $title ) ) {

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -189,6 +189,29 @@ function validate_domain_segment( string $segment ) : bool {
 	return (bool) preg_match( '/^' . REGEX_DOMAIN_SEGMENT . '$/', $segment );
 }
 
+function sanitize_domain_segment( string $segment ) : string {
+	$segment = wp_kses_no_null( $segment );
+	$segment = remove_accents( $segment );
+	$segment = sanitize_title_with_dashes( $segment, null, 'save' );
+
+	if ( strlen( $segment ) < 1 ) {
+		return '';
+	}
+
+	$segment = trim_segment_length( $segment );
+
+	return $segment;
+}
+
+function trim_segment_length( string $segment, int $length = 63 ) : string {
+	if ( strlen( $segment ) > $length ) {
+		$segment = substr( $segment, 0, $length );
+		$segment = rtrim( $segment, '-' );
+	}
+
+	return $segment;
+}
+
 /**
  * Validate a domain name.
  *

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -186,7 +186,7 @@ function output_add_site_page() {
  * @return bool True if valid, false otherwise.
  */
 function validate_domain_segment( string $segment ) : bool {
-	$segment = sanitize_domain_segment( $segment ); //var_dump( 'segment:', $segment );
+	$segment = sanitize_domain_segment( $segment );
 	return (bool) preg_match( '/^' . REGEX_DOMAIN_SEGMENT . '$/', $segment );
 }
 

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -242,6 +242,11 @@ function validate_path( $path ) {
 	$segments = explode( '/', trim( $path, '/' ) );
 
 	foreach ( $segments as $segment ) {
+		// Prevent paths with spaces.
+		if ( false !== stripos( $segment, ' ' ) ) {
+			return false;
+		}
+
 		if ( empty( $segment ) ) {
 			return false;
 		}

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -190,6 +190,15 @@ function validate_domain_segment( string $segment ) : bool {
 	return (bool) preg_match( '/^' . REGEX_DOMAIN_SEGMENT . '$/', $segment );
 }
 
+/**
+ * Sanitize a domain segment.
+ *
+ * Strips out invalid characters from a URL segment.
+ *
+ * @param string $segment Dirty segment to sanitize.
+ *
+ * @return string The cleaned segment.
+ */
 function sanitize_domain_segment( string $segment ) : string {
 	$segment = wp_kses_no_null( $segment );
 	$segment = remove_accents( $segment );

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -441,7 +441,7 @@ function handle_subdirectory( string $value ) : ?array {
 
 	return [
 		'domain' => idna_encode( $network_host ),
-		'path' => urlencode( $path ),
+		'path' => '/' . urlencode( $path ),
 	];
 }
 

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -7,6 +7,8 @@
 
 namespace Altis\CMS\Add_Site_UI;
 
+use Requests_IDNAEncoder;
+
 const REGEX_DOMAIN_SEGMENT = '(?![0-9]+$)(?!.*-$)(?!-)[a-zA-Z0-9-]{1,63}';
 
 /**

--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -15,18 +15,6 @@ const REGEX_DOMAIN_SEGMENT = '(?![0-9]+$)(?!.*-$)(?!-)[a-zA-Z0-9-]{1,63}';
 function bootstrap() {
 	add_action( 'admin_init', __NAMESPACE__ . '\\add_site_form_handler' );
 	add_action( 'load-site-new.php', __NAMESPACE__ . '\\output_add_site_page', 1000 );
-	add_filter( 'site_by_path_segments_count', __NAMESPACE__ . '\\filter_segments_count' );
-}
-
-/**
- * Override the default segments count.
- *
- * Arbitrarily allowing 4 URL segments.
- *
- * @return int The number of valid segments.
- */
-function filter_segments_count() : int {
-	return 4;
 }
 
 /**


### PR DESCRIPTION
`sanitize_text_field` does a lot of important work that we want to use for urls. However, what it _doesn't_ do, is disallow text strings from having spaces, which is also important for URLs.

Additionally, there is no handling for IDNAs or other variations that should be allowed. This PR:

* adds URL sanitization that covers additional steps that weren't being handled previously when new sites were created (this code was based off [the old HappyTables code](https://github.com/humanmade/happytables/blob/master/content/plugins-mu/ht-domains/ht-domains.php#L88-L144) for the same)
* pulls in the `Requests_IDNAEncoder` class to properly encode IDNAs
* adds URL encoding for subdirectory sites, so those respect internationalized characters as well (e.g. `domain.com/納豆`)

fixes #303 