### PR TITLE
Update post cloner to 1.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "altis/cms-installer": "^0.4.3",
     "johnbillion/extended-cpts": "^4.5.2",
     "humanmade/clean-html": "^2.0.0",
-    "humanmade/post-cloner": "~1.3.0",
+    "humanmade/post-cloner": "~1.4.0",
     "humanmade/authorship": "~0.2.6",
     "humanmade/altis-reusable-blocks": "~0.1.3",
     "humanmade/asset-loader": "^0.5.0"

--- a/docs/post-cloner.md
+++ b/docs/post-cloner.md
@@ -80,3 +80,9 @@ Allows overriding the allowlist of post statuses that are eligible for cloning. 
 **`post_cloner_permission_level: (string) $permission_level`**
 
 Allows overriding the minimum capability that a user must have to clone a post. Defaults to `publish_posts`.
+
+**`post_cloner_strip_cloned: (bool) $strip, (string) $permalink, (WP_Post) $post`**
+
+Filters whether to remove the suffix from the `post_cloner_name_append` filter from the cloned post permalink. Defaults to `false`.
+
+Only set this value to true if you have `%postid%` as part of your post's permalink otherwise WordPress will fail to match the post and return a 404.


### PR DESCRIPTION
Fixes the cloned post permalink issue and adds documentation for the `post_cloner_strip_cloned` filter.