### PR TITLE
Display user pagination in network/users.php

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -37,6 +37,14 @@ function bootstrap() {
 		add_filter( 'wp_is_large_network', function () use ( $config ) {
 			return $config['large-network'];
 		} );
+
+		if ( $config['large-network'] === true ) {
+			// Display user pagination in network/users.php even if the network is considered as large.
+			add_filter( 'users_list_table_query_args', function( $args ) {
+				$args['count_total'] = true;
+				return $args;
+			} );
+		}
 	}
 
 	if ( $config['login-logo'] ) {


### PR DESCRIPTION
Even if the network is considered large from within the config, display pagination when listing the network users in network/users.php

A network defined as large would prevent this and while Altis defines all networks as large by default, this was an annoying issue in the network users list.

This can be considered as a new feature and not a bug as it's a hack to a WP feature happening because of an Altis configuration field.