### PR TITLE
Remove the modern admin theme

### DIFF
--- a/inc/branding/namespace.php
+++ b/inc/branding/namespace.php
@@ -104,6 +104,7 @@ function remove_wp_admin_color_schemes() {
 		'ectoplasm',
 		'ocean',
 		'coffee',
+		'modern',
 	];
 
 	$user_admin_color = get_user_option( 'admin_color', get_current_user_id() );


### PR DESCRIPTION
This theme was added in WordPress 5.5 so needs backporting to Altis v5.

Fixes https://github.com/humanmade/product-dev/issues/680