### PR TITLE
WordPress 5.6.4 update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=7.1",
     "stuttter/wp-user-signups": "^5.0.1",
     "roots/wp-password-bcrypt": "1.0.0",
-    "johnpbloch/wordpress": "5.6.2",
+    "johnpbloch/wordpress": "5.6.4",
     "altis/cms-installer": "^0.4.3",
     "johnbillion/extended-cpts": "^4.5.1",
     "humanmade/clean-html": "^2.0.0",


### PR DESCRIPTION
Updates WordPress to the latest security patch.
https://wordpress.org/support/wordpress-version/version-5-6-4/