### PR TITLE
Update WordPress to 5.5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=7.1",
     "stuttter/wp-user-signups": "^5.0.1",
     "roots/wp-password-bcrypt": "1.0.0",
-    "johnpbloch/wordpress": "5.5.3",
+    "johnpbloch/wordpress": "5.5.5",
     "altis/cms-installer": "^0.4.3",
     "johnbillion/extended-cpts": "^4.4.0",
     "humanmade/clean-html": "^2.0.0",


### PR DESCRIPTION
Updates WordPress to the latest security patch
- [Release Notes](https://wordpress.org/support/wordpress-version/version-5-5-5/)