### PR TITLE
add simple local avatars

### DIFF
--- a/assets/branding.css
+++ b/assets/branding.css
@@ -41,3 +41,8 @@ body.wp-admin:not(.folded) #wp-admin-bar-altis {
 #dashboard_right_now #wp-version-message {
 	display: none;
 }
+
+/* Hide the User Profile Picture field. Replaced by Avatar on the same page. */
+.wp-admin tr.user-profile-picture {
+	display: none;
+}

--- a/assets/branding.css
+++ b/assets/branding.css
@@ -41,8 +41,3 @@ body.wp-admin:not(.folded) #wp-admin-bar-altis {
 #dashboard_right_now #wp-version-message {
 	display: none;
 }
-
-/* Hide the User Profile Picture field. Replaced by Avatar on the same page. */
-.wp-admin tr.user-profile-picture {
-	display: none;
-}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "humanmade/clean-html": "^2.0.0",
     "humanmade/authorship": "~0.2.7",
     "humanmade/altis-reusable-blocks": "~0.1.3",
-    "humanmade/asset-loader": "^0.5.0"
+    "humanmade/asset-loader": "^0.5.0",
+    "10up/simple-local-avatars": "~2.2.0"
   },
   "autoload": {
     "files": [
@@ -40,6 +41,7 @@
   "extra": {
     "altis": {
       "install-overrides": [
+        "10up/simple-local-avatars",
         "stuttter/wp-user-signups",
         "humanmade/authorship",
         "humanmade/altis-reusable-blocks",

--- a/docs/local-avatars.md
+++ b/docs/local-avatars.md
@@ -1,0 +1,49 @@
+# Local Avatars
+
+Altis provides a way to customize your profile picture via the [Simple Local Avatars](https://github.com/10up/simple-local-avatars) plugin. By default, a [Gravatar](https://en.gravatar.com/) will be used to fetch your profile picture. However, if you don't have an existing Gravatar, and have no desire to create one, you can use any image uploaded to the media library -- or upload a new image -- and set that as your profile picture or "avatar".
+
+By default, local avatars is enabled and the default profile picture field on the Edit Profile page is hidden. However, this can be disabled and the default functionality restored by updating your Altis config:
+
+```json
+{
+	"extra": {
+		"altis": {
+			"cms": {
+				"local-avatars": false
+			}
+		}
+	}
+}
+```
+
+## Filters
+
+### `simple_local_avatars_dynamic_resize`
+
+Allows automatic rescaling to be turned off. 
+
+**Parameters**
+
+**`$allow_resize`** _(bool)_ Whether to allow dynamic resizing.
+
+**Example**
+
+```php
+add_filter( 'simple_local_avatars_dynamic_resize', '__return_false' );
+```
+
+### `simple_local_avatars_upload_limit`
+
+Allows overriding of the maximum allowable file size for avatar uploads. Defaults to the WordPress maximum default upload size.
+
+**Parameters**
+
+**`$bytes`** _(int)_ The maximum byte size.
+
+**Example**
+
+```php
+add_filter( 'simple_local_avatars_upload_limit', function() {
+	return 2 * 1024; // Max 2MB.
+} );
+```

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -272,6 +272,7 @@ function load_muplugins() {
  * Load plugins that are bundled with the CMS module.
  */
 function load_plugins() {
+	require_once Altis\ROOT_DIR . '/vendor/10up/simple-local-avatars/simple-local-avatars.php';
 	require_once Altis\ROOT_DIR . '/vendor/stuttter/wp-user-signups/wp-user-signups.php';
 
 	$config = Altis\get_config()['modules']['cms'];

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -280,6 +280,10 @@ function load_plugins() {
 	if ( $config['authorship'] ) {
 		require_once Altis\ROOT_DIR . '/vendor/humanmade/authorship/plugin.php';
 	}
+
+	if ( $config['local-avatars'] ) {
+		require_once Altis\ROOT_DIR . '/vendor/10up/simple-local-avatars/simple-local-avatars.php';
+	}
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -272,7 +272,6 @@ function load_muplugins() {
  * Load plugins that are bundled with the CMS module.
  */
 function load_plugins() {
-	require_once Altis\ROOT_DIR . '/vendor/10up/simple-local-avatars/simple-local-avatars.php';
 	require_once Altis\ROOT_DIR . '/vendor/stuttter/wp-user-signups/wp-user-signups.php';
 
 	$config = Altis\get_config()['modules']['cms'];
@@ -283,6 +282,13 @@ function load_plugins() {
 
 	if ( $config['local-avatars'] ) {
 		require_once Altis\ROOT_DIR . '/vendor/10up/simple-local-avatars/simple-local-avatars.php';
+
+		// Hide the User Profile Picture field if local avatars is active. Replaced by the Avatar field on the same page.
+		add_action( 'admin_head', function() {
+			echo '<style>
+				.wp-admin tr.user-profile-picture { display: none; }
+			</style>';
+		} );
 	}
 }
 

--- a/load.php
+++ b/load.php
@@ -25,6 +25,7 @@ add_action( 'altis.modules.init', function () {
 			'disable-spam' => true,
 		],
 		'authorship' => false,
+		'local-avatars' => true,
 	];
 	Altis\register_module( 'cms', __DIR__, 'CMS', $default_settings, __NAMESPACE__ . '\\bootstrap' );
 }, 5 );


### PR DESCRIPTION
Supersedes #111 
Fixes #7 

* Adds Simple Local Avatars to CMS module
* Adds `10up/simple-local-avatars` to the install overrides in the `composer.json`
* Adds a config option to enable/disable local avatars
* Hides the default Profile Picture field if local avatars is enabled
* Adds documentation about the config option and available filters.