### PR TITLE
#393 Add a link to WordPress RSS documentation

### DIFF
--- a/docs/rss.md
+++ b/docs/rss.md
@@ -17,3 +17,5 @@ By default the RSS Feeds are enabled. If you wish to disable it, set the `feeds`
 	}
 }
 ```
+
+For more information on RSS feeds, please see the [WordPress RSS documentation](https://wordpress.org/support/article/wordpress-feeds/).


### PR DESCRIPTION
Adds a link to the WordPress documentation page for RSS feeds. 

See #393.