### PR TITLE
FIx code comment in documentation for `simple_local_avatars_upload_limit` filter

### DIFF
--- a/docs/local-avatars.md
+++ b/docs/local-avatars.md
@@ -44,6 +44,6 @@ Allows overriding of the maximum allowable file size for avatar uploads. Default
 
 ```php
 add_filter( 'simple_local_avatars_upload_limit', function() {
-	return 2 * 1024; // Max 2MB.
+	return 2 * 1024; // Max 2KB.
 } );
 ```

--- a/docs/local-avatars.md
+++ b/docs/local-avatars.md
@@ -44,6 +44,6 @@ Allows overriding of the maximum allowable file size for avatar uploads. Default
 
 ```php
 add_filter( 'simple_local_avatars_upload_limit', function() {
-	return 2 * 1024; // Max 2KB.
+	return 2 * 1024 * 1024; // Max 2MB.
 } );
 ```


### PR DESCRIPTION
This filter is operating on bytes, not kilobytes, so `2 * 1024` is 2KB, not 2MB.