### PR TITLE
Fix logic error for defining WP_INITIAL_INSTALL

### DIFF
--- a/inc/cli/namespace.php
+++ b/inc/cli/namespace.php
@@ -28,7 +28,7 @@ function bootstrap() {
 function is_initial_install() : bool {
 	// Support for PHPUnit & direct calls to install.php.
 	// phpcs:ignore -- Ignoring requirement for isset on $_SERVER['PHP_SELF'] and wp_unslash().
-	if ( php_sapi_name() === 'cli' && basename( $_SERVER['PHP_SELF'] ) === 'install.php' ) {
+	if ( php_sapi_name() === 'cli' || basename( $_SERVER['PHP_SELF'] ) === 'install.php' ) {
 		return true;
 	}
 


### PR DESCRIPTION
@roborourke  I don't think this code does quite what you intended. The comment for this condition suggests this should return true for PHP Unit and direct calls to `install.php`. 

However your condition uses `&&` which is the same, I think you mean `||`.

I should also note that `php_sapi_name() === 'cli'` could return true in other circumstances such as when running WP-CLI commands, or WP-Shell, so I'm not convinced this is a robust solution for this issue.  

