### PR TITLE
Limit the blog permalinks fix to main site only

### DIFF
--- a/inc/permalinks/namespace.php
+++ b/inc/permalinks/namespace.php
@@ -22,7 +22,7 @@ function bootstrap() {
  * @return string
  */
 function remove_blog_prefix( string $value ) : string {
-	if ( strpos( $value, '/blog' ) === 0 ) {
+	if ( is_multisite() && is_main_site() && strpos( $value, '/blog' ) === 0 ) {
 		$value = preg_replace( '#^/blog#', '', $value );
 	}
 


### PR DESCRIPTION
The bug we're trying to fix is only limited to the main site of a network, so the fix should be too.

Related https://github.com/humanmade/altis-cms/issues/70, https://github.com/WordPress/WordPress/blame/44caec31bdc9cd0e65c6d433f22ca9e49e1a2683/wp-admin/options-permalink.php#L225