### PR TITLE
[Backport v9-branch] Update to Reusable Blocks 0.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "altis/cms-installer": "^0.4.3",
     "johnbillion/extended-cpts": "^4.5.2",
     "humanmade/clean-html": "^2.0.0",
-    "humanmade/authorship": "~0.2.8",
-    "humanmade/altis-reusable-blocks": "~0.1.3",
+    "humanmade/authorship": "~0.2.9",
+    "humanmade/altis-reusable-blocks": "~0.2.0",
     "humanmade/asset-loader": "^0.5.0",
     "10up/simple-local-avatars": "~2.2.0"
   },


### PR DESCRIPTION
Backporting #457

Fixes a filter deprecation warning.