### PR TITLE
[Backport v9-branch] Update johnpbloch/wordpress requirement from 5.8.1 to 5.8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=7.1",
     "stuttter/wp-user-signups": "^5.0.2",
     "roots/wp-password-bcrypt": "1.0.0",
-    "johnpbloch/wordpress": "5.8.1",
+    "johnpbloch/wordpress": "5.8.2",
     "altis/cms-installer": "^0.4.3",
     "johnbillion/extended-cpts": "^4.5.2",
     "humanmade/clean-html": "^2.0.0",


### PR DESCRIPTION
Backporting #473

--------------


Updates the requirements on [johnpbloch/wordpress](https://github.com/johnpbloch/wordpress) to permit the latest version.
- [Release notes](https://github.com/johnpbloch/wordpress/releases)
- [Commits](https://github.com/johnpbloch/wordpress/compare/5.8.1...5.8.2)

---
updated-dependencies:
- dependency-name: johnpbloch/wordpress
  dependency-type: direct:production
...