### PR TITLE
Load plugins after initial install

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -109,9 +109,8 @@ function bootstrap() {
 
 	add_filter( 'login_headerurl', __NAMESPACE__ . '\\login_header_url' );
 
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		WP_CLI::add_hook( 'after_invoke:core multisite-install', __NAMESPACE__ . '\\setup_user_signups_on_install' );
-	}
+	// Setup signups db tables on migrate.
+	add_action( 'altis.migrate', __NAMESPACE__ . '\\setup_user_signups_on_migrate' );
 
 	// Fix network admin site actions.
 	add_filter( 'network_admin_url', __NAMESPACE__ . '\\fix_network_action_confirmation' );


### PR DESCRIPTION
The signups plugin will try to create or upgrade its db tables on `admin_init` now. Loading these was throwing up errors during the installation process.