### PR TITLE
Increase the admin toolbar hover contrast.

### DIFF
--- a/assets/admin-color-scheme.css
+++ b/assets/admin-color-scheme.css
@@ -324,7 +324,8 @@ ul#adminmenu > li.current > a.current::after {
 #wpadminbar .quicklinks .menupop ul li a,
 #wpadminbar .quicklinks .menupop.hover ul li a,
 #wpadminbar.nojs .quicklinks .menupop:hover ul li a {
-	color: #a2aabe;
+	color: #e2ecf1;
+	border-left: 3px solid transparent;
 }
 
 #wpadminbar .quicklinks li .blavatar,
@@ -351,6 +352,10 @@ ul#adminmenu > li.current > a.current::after {
 #wpadminbar li:hover #adminbarsearch::before,
 #wpadminbar li #adminbarsearch.adminbar-focused::before {
 	color: #fff;
+}
+
+#wpadminbar .quicklinks .menupop.hover ul li > a:hover {
+	border-left-color: #fff;
 }
 
 #wpadminbar .quicklinks li a:hover .blavatar,

--- a/assets/admin-color-scheme.css
+++ b/assets/admin-color-scheme.css
@@ -324,7 +324,7 @@ ul#adminmenu > li.current > a.current::after {
 #wpadminbar .quicklinks .menupop ul li a,
 #wpadminbar .quicklinks .menupop.hover ul li a,
 #wpadminbar.nojs .quicklinks .menupop:hover ul li a {
-	color: #e2ecf1;
+	color: #a2aabe;
 }
 
 #wpadminbar .quicklinks li .blavatar,


### PR DESCRIPTION
### Issue
#359 When hovering over an admin toolbar menu item, the change in colour is barely noticeable. It changes from very light grey to white. ( Hovering over Media )

![current-state](https://user-images.githubusercontent.com/16571365/151334140-c517436b-58f7-4d21-8feb-b74ed09ae556.png)


### Solution
Changed the menu item color from that of the sidebar links to keep some consistency. ( Hovering over Media )

![new-state](https://user-images.githubusercontent.com/16571365/151334175-ea00887c-15b6-46cd-a181-78a911d2d774.png)

