### PR TITLE
Enqueued script warning for wp-editor on widgets screen

### DIFF
--- a/inc/branding/namespace.php
+++ b/inc/branding/namespace.php
@@ -363,14 +363,20 @@ function remove_howdy_greeting( WP_Admin_Bar $wp_admin_bar ) {
  * Enqueue branding script for the post previews.
  */
 function enqueue_block_editor_branding_assets() {
+
+	global $pagenow;
+
+	$dependants = [
+		'wp-element',
+		'wp-hooks',
+	];
+
+	$dependants[] = ( $pagenow === 'widgets.php' ? 'wp-edit-widgets' : 'wp-editor' );
+
 	wp_enqueue_script(
 		'altis-branding',
 		plugin_dir_url( dirname( __FILE__, 2 ) ) . 'assets/branding.js',
-		[
-			'wp-element',
-			'wp-editor',
-			'wp-hooks',
-		],
+		$dependants,
 		false,
 		true
 	);

--- a/inc/branding/namespace.php
+++ b/inc/branding/namespace.php
@@ -363,20 +363,21 @@ function remove_howdy_greeting( WP_Admin_Bar $wp_admin_bar ) {
  * Enqueue branding script for the post previews.
  */
 function enqueue_block_editor_branding_assets() {
-
 	global $pagenow;
 
-	$dependants = [
-		'wp-element',
-		'wp-hooks',
-	];
-
-	$dependants[] = ( $pagenow === 'widgets.php' ? 'wp-edit-widgets' : 'wp-editor' );
+	// Return early when viewing the customizer or widgets screen.
+	if ( is_customize_preview() || 'widgets.php' === $pagenow ) {
+		return;
+	}
 
 	wp_enqueue_script(
 		'altis-branding',
 		plugin_dir_url( dirname( __FILE__, 2 ) ) . 'assets/branding.js',
-		$dependants,
+		[
+			'wp-element',
+			'wp-editor',
+			'wp-hooks',
+		],
 		false,
 		true
 	);


### PR DESCRIPTION
This PR fixes the original issue reported in #482 where the below error shown when on the widgets page:

> wp_enqueue_script() was called incorrectly. "wp-editor" script should not be enqueued together with the new widgets editor (wp-edit-widgets or wp-customize-widgets). Please see Debugging in WordPress for more information. (This message was added in version 5.8.0.)

Steps to confirm:

1. Login to the site
2. View the widgets page
3. View query Monitor, you shouldn't see the error mentioned above that `wp_enqueue_script() was called incorrectly.`