### PR TITLE
Add `--prefer-dist` to composer install command

### DIFF
--- a/.build-script
+++ b/.build-script
@@ -5,7 +5,7 @@
 #====================#
 
 # Install composer dependencies
-composer install --no-dev --optimize-autoloader --apcu-autoloader
+composer install --no-dev --prefer-dist --optimize-autoloader --apcu-autoloader
 
 # Edit below this line to add any additional build steps.
 #


### PR DESCRIPTION
Slack convo for reference: https://hmn.slack.com/archives/C03K3J34A/p1660143713204989

This can help to keep build sizes down by fetching software without superfluous files.