### PR TITLE
Return an HTTP 500 response code when there's a configuration problem

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -71,6 +71,7 @@ $required_constants = [
 
 foreach ( $required_constants as $constant ) {
 	if ( ! defined( $constant ) ) {
+		http_response_code( 500 );
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		die( "$constant constant is not defined." );
 	}


### PR DESCRIPTION
If there's a configuration problem and an expected constant is missing, the application still responds with a `200`. This changes that to a `500`.