### PR TITLE
Change Query Monitor styling.

### DIFF
--- a/assets/admin-color-scheme.css
+++ b/assets/admin-color-scheme.css
@@ -1044,7 +1044,8 @@ textarea:focus {
 
 #query-monitor-main #qm-wrapper #qm-panel-menu li button:hover,
 #query-monitor-main #qm-wrapper #qm-panel-menu li button:focus {
-	background-color: #e5f8ff !important;
+	background-color: var( --altis-blue ) !important;
+	color: var( --altis-white ) !important;
 }
 
 #query-monitor-main #qm-wrapper #qm-panel-menu li button:active {
@@ -1057,12 +1058,17 @@ textarea:focus {
 	border-color: var( --altis-blue ) !important;
 }
 
+#query-monitor-main #qm-wrapper .qm tbody tr:hover .qm-toggle {
+	border-color: var( --altis-white ) !important;
+}
+
+
 #query-monitor-main #qm-wrapper .qm button.qm-filter-trigger,
 #query-monitor-main #qm-wrapper .qm button.qm-filter-trigger code,
 #query-monitor-main #qm-wrapper .qm tbody .qm-warn a code,
 #query-monitor-main #qm-wrapper .qm a code,
 #query-monitor-main #qm-wrapper .qm a {
-	color: var( --altis-blue ) !important;
+	color: var( --altis-aqua ) !important;
 }
 
 #query-monitor-main #qm-wrapper .qm button.qm-filter-trigger::after,
@@ -1083,6 +1089,11 @@ textarea:focus {
 	color: var( --altis-bright-blue ) !important;
 }
 
+#query-monitor-main #qm-wrapper .qm button.qm-filter-trigger:hover svg,
+#query-monitor-main #qm-wrapper .qm a:hover svg {
+	fill: var( --altis-bright-blue ) !important;
+}
+
 #query-monitor-main #qm-wrapper .qm tbody tr:hover th,
 #query-monitor-main #qm-wrapper .qm tbody tr:hover td,
 #query-monitor-main #qm-wrapper .qm tbody tr.qm-odd.qm-hovered th,
@@ -1091,5 +1102,30 @@ textarea:focus {
 #query-monitor-main #qm-wrapper .qm tbody tr.qm-odd:hover td,
 #query-monitor-main #qm-wrapper .qm tbody tr.qm-hovered th,
 #query-monitor-main #qm-wrapper .qm tbody tr.qm-hovered td {
-	background-color: #e5f8ff !important;
+	background-color: var( --altis-blue ) !important;
+	color: var( --altis-white ) !important;
+}
+
+#query-monitor-main #qm-wrapper .qm tbody tr:hover code,
+#query-monitor-main #qm-wrapper .qm tbody tr:hover li,
+#query-monitor-main #qm-wrapper .qm tbody tr:hover pre,
+#query-monitor-main #qm-wrapper .qm tbody tr:hover .qm-info,
+#query-monitor-main #qm-wrapper .qm tbody tr.qm-hovered code,
+#query-monitor-main #qm-wrapper .qm tbody tr.qm-hovered li,
+#query-monitor-main #qm-wrapper .qm tbody tr.qm-hovered pre,
+#query-monitor-main #qm-wrapper .qm tbody tr.qm-hovered .qm-info {
+	color: var( --altis-off-white ) !important;
+}
+
+
+#query-monitor-main #qm-wrapper .qm tbody tr:hover a,
+#query-monitor-main #qm-wrapper .qm tbody tr:hover button.qm-filter-trigger,
+#query-monitor-main #qm-wrapper .qm tbody tr:hover button.qm-filter-trigger code {
+	color: var( --altis-white ) !important;
+	text-decoration: underline !important;
+}
+
+#query-monitor-main #qm-wrapper .qm tbody tr:hover a.qm-link svg,
+#query-monitor-main #qm-wrapper .qm tbody tr:hover button.qm-filter-trigger svg{
+	fill: var( --altis-white ) !important;
 }

--- a/assets/admin-color-scheme.css
+++ b/assets/admin-color-scheme.css
@@ -1062,7 +1062,6 @@ textarea:focus {
 	border-color: var( --altis-white ) !important;
 }
 
-
 #query-monitor-main #qm-wrapper .qm button.qm-filter-trigger,
 #query-monitor-main #qm-wrapper .qm button.qm-filter-trigger code,
 #query-monitor-main #qm-wrapper .qm tbody .qm-warn a code,
@@ -1117,7 +1116,6 @@ textarea:focus {
 	color: var( --altis-off-white ) !important;
 }
 
-
 #query-monitor-main #qm-wrapper .qm tbody tr:hover a,
 #query-monitor-main #qm-wrapper .qm tbody tr:hover button.qm-filter-trigger,
 #query-monitor-main #qm-wrapper .qm tbody tr:hover button.qm-filter-trigger code {
@@ -1126,6 +1124,6 @@ textarea:focus {
 }
 
 #query-monitor-main #qm-wrapper .qm tbody tr:hover a.qm-link svg,
-#query-monitor-main #qm-wrapper .qm tbody tr:hover button.qm-filter-trigger svg{
+#query-monitor-main #qm-wrapper .qm tbody tr:hover button.qm-filter-trigger svg {
 	fill: var( --altis-white ) !important;
 }


### PR DESCRIPTION
Related issue - #657 

This PR resolves styling issues in Query Monitor's for Dark & Light appearance. 

#### Steps to reproduce:

1. Login to the wp-admin area.
2. Click on the Query Monitor tab so it shows at the bottom of the window.
3. Hover any of the tabs and observe the background color and text color are light making it harder to read.
4. Click on Altis Config and hover any of the modules and observer the background color and test color too are hard to read.

#### Before Screenshots
![Screenshot 2022-10-10 at 13 16 20](https://user-images.githubusercontent.com/16571365/194854256-ce81cf31-ac31-4c96-b79f-b5d9d8722725.png)
![Screenshot 2022-10-10 at 13 16 11](https://user-images.githubusercontent.com/16571365/194854269-bf6883ee-b651-4725-b42f-964cd8475e1f.png)

#### After Screenshots
Light appearance - Hovering on a module in the Altis Config tab
![Screenshot 2022-10-17 at 09 50 11](https://user-images.githubusercontent.com/16571365/196119864-0e7a1c9c-ec35-4eb9-b1a3-a1bdabd14512.png)

Light appearance - Hovering on another module while the Altis Config tab is "active"
![Screenshot 2022-10-17 at 09 54 44](https://user-images.githubusercontent.com/16571365/196120987-52237895-504a-4bac-b0a9-3294efe2e188.png)

Dark appearance - Hovering on a module in the Altis Config tab
![Screenshot 2022-10-17 at 09 50 59](https://user-images.githubusercontent.com/16571365/196119901-94303a54-b20f-49df-8a0a-b99c9e9bf7bf.png)

Dark appearance - Hovering on another module while the Altis Config tab is "active"
![Screenshot 2022-10-17 at 09 54 32](https://user-images.githubusercontent.com/16571365/196121112-5277f2b0-74e0-4b65-9c3b-d104ac3f2c82.png)
