### PR TITLE
Update to WordPress 5.9.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=7.1",
     "stuttter/wp-user-signups": "^5.0.2",
     "roots/wp-password-bcrypt": "1.1.0",
-    "johnpbloch/wordpress": "5.9.4",
+    "johnpbloch/wordpress": "5.9.5",
     "altis/cms-installer": "^0.4.3",
     "johnbillion/extended-cpts": "^4.5.2",
     "humanmade/clean-html": "^2.0.0",


### PR DESCRIPTION
Security update: https://wordpress.org/news/2022/10/wordpress-6-0-3-security-release/