### PR TITLE
Update to WordPress 6.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=7.1",
     "stuttter/wp-user-signups": "^5.0.2",
     "roots/wp-password-bcrypt": "1.1.0",
-    "johnpbloch/wordpress": "6.0.3",
+    "johnpbloch/wordpress": "6.1.1",
     "altis/cms-installer": "^0.4.3",
     "humanmade/clean-html": "^2.0.0",
     "humanmade/authorship": "~0.2.12",


### PR DESCRIPTION
Updates the composer.json requirement to WordPress 6.1.1. Announcements and dev notes:

* https://wordpress.org/news/2022/11/misha/
* https://wordpress.org/news/2022/11/wordpress-6-1-1-maintenance-release/
* https://make.wordpress.org/core/tag/6-1/