### PR TITLE
Fix a PHP8 TypeError in 10up/simple-local-avatars

### DIFF
--- a/lib/simple-local-avatars/includes/class-simple-local-avatars.php
+++ b/lib/simple-local-avatars/includes/class-simple-local-avatars.php
@@ -925,7 +925,7 @@ class Simple_Local_Avatars {
 		$meta_value = array();
 
 		// set the new avatar
-		if ( is_int( $url_or_media_id + 0 ) ) {
+		if ( is_numeric( $url_or_media_id ) ) {
 			$meta_value['media_id'] = $url_or_media_id;
 			$url_or_media_id        = wp_get_attachment_url( $url_or_media_id );
 		}


### PR DESCRIPTION
There is a TypeError with PHP8 that's been fixed upstream and released in a newer version (with other changes) which we'll ship with v14. This PR backports the fix alone to v13.

See:

* https://github.com/10up/simple-local-avatars/pull/183
* https://github.com/10up/simple-local-avatars/commit/9f28dc352fae18a6fb9388c478bf7815c920b915