### PR TITLE
Reduce the style overrides for Query Monitor

### DIFF
--- a/assets/admin-color-scheme.css
+++ b/assets/admin-color-scheme.css
@@ -1036,6 +1036,10 @@ textarea:focus {
 	fill: rgba( 70, 103, 222, 0.3 ) !important;
 }
 
+/**
+ * Query Monitor overrides
+ */
+
 #query-monitor-main #qm-wrapper #qm-panel-menu li button[aria-selected="true"],
 #query-monitor-main #qm-wrapper #qm-panel-menu li button[aria-selected="true"]:hover,
 #query-monitor-main #qm-wrapper #qm-panel-menu li button[aria-selected="true"]:focus {
@@ -1046,84 +1050,4 @@ textarea:focus {
 #query-monitor-main #qm-wrapper #qm-panel-menu li button:focus {
 	background-color: var( --altis-blue ) !important;
 	color: var( --altis-white ) !important;
-}
-
-#query-monitor-main #qm-wrapper #qm-panel-menu li button:active {
-	text-shadow: none !important;
-}
-
-#query-monitor-main #qm-wrapper .qm button.qm-button,
-#query-monitor-main #qm-wrapper .qm .qm-toggle {
-	background-color: var( --altis-blue ) !important;
-	border-color: var( --altis-blue ) !important;
-}
-
-#query-monitor-main #qm-wrapper .qm tbody tr:hover .qm-toggle {
-	border-color: var( --altis-white ) !important;
-}
-
-#query-monitor-main #qm-wrapper .qm button.qm-filter-trigger,
-#query-monitor-main #qm-wrapper .qm button.qm-filter-trigger code,
-#query-monitor-main #qm-wrapper .qm tbody .qm-warn a code,
-#query-monitor-main #qm-wrapper .qm a code,
-#query-monitor-main #qm-wrapper .qm a {
-	color: var( --altis-aqua ) !important;
-}
-
-#query-monitor-main #qm-wrapper .qm button.qm-filter-trigger::after,
-#query-monitor-main #qm-wrapper .qm button.qm-filter-trigger:focus,
-#query-monitor-main #qm-wrapper .qm button.qm-filter-trigger:hover,
-#query-monitor-main #qm-wrapper .qm button.qm-filter-trigger code::after,
-#query-monitor-main #qm-wrapper .qm button.qm-filter-trigger code:focus,
-#query-monitor-main #qm-wrapper .qm button.qm-filter-trigger code:hover,
-#query-monitor-main #qm-wrapper .qm tbody .qm-warn a code::after,
-#query-monitor-main #qm-wrapper .qm tbody .qm-warn a code:focus,
-#query-monitor-main #qm-wrapper .qm tbody .qm-warn a code:hover,
-#query-monitor-main #qm-wrapper .qm a code::after,
-#query-monitor-main #qm-wrapper .qm a code:focus,
-#query-monitor-main #qm-wrapper .qm a code:hover,
-#query-monitor-main #qm-wrapper .qm a::after,
-#query-monitor-main #qm-wrapper .qm a:focus,
-#query-monitor-main #qm-wrapper .qm a:hover {
-	color: var( --altis-bright-blue ) !important;
-}
-
-#query-monitor-main #qm-wrapper .qm button.qm-filter-trigger:hover svg,
-#query-monitor-main #qm-wrapper .qm a:hover svg {
-	fill: var( --altis-bright-blue ) !important;
-}
-
-#query-monitor-main #qm-wrapper .qm tbody tr:hover th,
-#query-monitor-main #qm-wrapper .qm tbody tr:hover td,
-#query-monitor-main #qm-wrapper .qm tbody tr.qm-odd.qm-hovered th,
-#query-monitor-main #qm-wrapper .qm tbody tr.qm-odd.qm-hovered td,
-#query-monitor-main #qm-wrapper .qm tbody tr.qm-odd:hover th,
-#query-monitor-main #qm-wrapper .qm tbody tr.qm-odd:hover td,
-#query-monitor-main #qm-wrapper .qm tbody tr.qm-hovered th,
-#query-monitor-main #qm-wrapper .qm tbody tr.qm-hovered td {
-	background-color: var( --altis-blue ) !important;
-	color: var( --altis-white ) !important;
-}
-
-#query-monitor-main #qm-wrapper .qm tbody tr:hover code,
-#query-monitor-main #qm-wrapper .qm tbody tr:hover li,
-#query-monitor-main #qm-wrapper .qm tbody tr:hover pre,
-#query-monitor-main #qm-wrapper .qm tbody tr:hover .qm-info,
-#query-monitor-main #qm-wrapper .qm tbody tr.qm-hovered code,
-#query-monitor-main #qm-wrapper .qm tbody tr.qm-hovered li,
-#query-monitor-main #qm-wrapper .qm tbody tr.qm-hovered pre,
-#query-monitor-main #qm-wrapper .qm tbody tr.qm-hovered .qm-info {
-	color: var( --altis-off-white ) !important;
-}
-
-#query-monitor-main #qm-wrapper .qm tbody tr:hover a,
-#query-monitor-main #qm-wrapper .qm tbody tr:hover button.qm-filter-trigger,
-#query-monitor-main #qm-wrapper .qm tbody tr:hover button.qm-filter-trigger code {
-	color: var( --altis-white ) !important;
-	text-decoration: underline !important;
-}
-
-#query-monitor-main #qm-wrapper .qm tbody tr:hover a.qm-link svg,
-#query-monitor-main #qm-wrapper .qm tbody tr:hover button.qm-filter-trigger svg {
-	fill: var( --altis-white ) !important;
 }


### PR DESCRIPTION
Some style overrides are in place for Query Monitor so that its styling more closely matches that of the purple Altis colour scheme in the admin area. However:

* The colours in these overrides are too stark (eg. dark purple for table row hover instead of pale blue)
* There are several bugs (eg. trailing icons on links aren't visible, links don't have hover states)
* The overrides aren't easily maintainable as QM evolves

These style overrides make it quite jarring to use the tool. I propose to remove all the style overrides for QM except for the Altis purple used in the main left hand side navigation menu.

## Before

Harshly contrasting table row hover state:

<img width="1493" alt="" src="https://user-images.githubusercontent.com/208434/226385771-2044fea7-ba55-4f2b-a766-928edb62796e.png">

Barely visible trailing icon on links:

<img width="265" alt="" src="https://user-images.githubusercontent.com/208434/226385958-e4fd5258-4681-4975-b6b1-9559ce4e3b88.png">

## After

Correctly styled row hover state:

<img width="1494" alt="" src="https://user-images.githubusercontent.com/208434/226386302-adb9ee1f-593d-4e22-ab73-99fed002f852.png">

Correctly styled trailing icon on links:

<img width="249" alt="" src="https://user-images.githubusercontent.com/208434/226386567-a5a3c8eb-b26c-4021-849b-6b2810ea321a.png">

Altis purple remains for the main nav menu:

<img width="181" alt="" src="https://user-images.githubusercontent.com/208434/226386755-5f701a2b-acbb-437d-8457-b6e8f9b4cc61.png">
