### PR TITLE
Update WordPress to version 6.2..0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=7.1",
     "stuttter/wp-user-signups": "^5.0.2",
     "roots/wp-password-bcrypt": "1.1.0",
-    "johnpbloch/wordpress": "6.1.1",
+    "johnpbloch/wordpress": "6.2.0",
     "altis/cms-installer": "^0.4.3",
     "humanmade/clean-html": "^2.0.0",
     "humanmade/altis-reusable-blocks": "~0.2.4",


### PR DESCRIPTION
Updates `composer.json` to require WordPress 6.2.0
Addresses #706 