### PR TITLE
Update to WordPress 6.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=7.1",
     "stuttter/wp-user-signups": "^5.0.2",
     "roots/wp-password-bcrypt": "1.1.0",
-    "johnpbloch/wordpress": "6.1.1",
+    "johnpbloch/wordpress": "6.1.2",
     "altis/cms-installer": "^0.4.4",
     "humanmade/clean-html": "^2.0.0",
     "humanmade/altis-reusable-blocks": "~0.2.4",


### PR DESCRIPTION
Part of the 6.2.1 maintenance/security release: https://wordpress.org/news/2023/05/wordpress-6-2-1-maintenance-security-release/