### PR TITLE
Update WordPress to 6.4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=7.1",
     "stuttter/wp-user-signups": "^5.0.2",
     "roots/wp-password-bcrypt": "1.1.0",
-    "johnpbloch/wordpress": "6.3.2",
+    "johnpbloch/wordpress": "6.4.2",
     "altis/cms-installer": "^0.4.4",
     "humanmade/clean-html": "^2.0.0",
     "humanmade/altis-reusable-blocks": "~0.2.4",


### PR DESCRIPTION
Upgrades WordPress to version 6.4.2
Fixes https://github.com/humanmade/altis-cms/issues/774