### PR TITLE
Fixes CodeCeption tests

### DIFF
--- a/tests/acceptance/SignupsCest.php
+++ b/tests/acceptance/SignupsCest.php
@@ -44,6 +44,9 @@ class SignupsCest {
 		// Login with that user.
 		$I->amOnPage( '/wp-login.php?action=logout' );
 		$I->click( '//a[contains(@href,"action=logout")]' );
+
+		$I->wait(5); // wait for 5 seconds to avoid rate limiting.
+
 		$I->loginAs( 'signo', $pass );
 	}
 }

--- a/tests/acceptance/SignupsCest.php
+++ b/tests/acceptance/SignupsCest.php
@@ -45,7 +45,7 @@ class SignupsCest {
 		$I->amOnPage( '/wp-login.php?action=logout' );
 		$I->click( '//a[contains(@href,"action=logout")]' );
 
-		$I->wait(5); // wait for 5 seconds to avoid rate limiting.
+		$I->wait( 5 ); // wait for 5 seconds to avoid rate limiting.
 
 		$I->loginAs( 'signo', $pass );
 	}

--- a/tests/acceptance/SitesCest.php
+++ b/tests/acceptance/SitesCest.php
@@ -18,7 +18,7 @@ class SiteCest {
 	 * @return void
 	 */
 	public function testSitesManagementActions( AcceptanceTester $I ) {
-		$I->wait(10); // wait for 10 seconds to avoid rate limiting.
+		$I->wait( 10 ); // wait for 10 seconds to avoid rate limiting.
 
 		$I->wantToTest( 'I want to manage my network sites.' );
 		$I->loginAsAdmin();
@@ -55,7 +55,7 @@ class SiteCest {
 		$I->amOnPage( '/testsubdir/' );
 		$I->see( 'This site has been archived or suspended.' );
 
-		$I->wait(10); // wait for 10 seconds to avoid rate limiting.
+		$I->wait( 10 ); // wait for 10 seconds to avoid rate limiting.
 
 		// Mark a site as spam.
 		$I->loginAsAdmin();

--- a/tests/acceptance/SitesCest.php
+++ b/tests/acceptance/SitesCest.php
@@ -18,6 +18,8 @@ class SiteCest {
 	 * @return void
 	 */
 	public function testSitesManagementActions( AcceptanceTester $I ) {
+		$I->wait(10); // wait for 10 seconds to avoid rate limiting.
+
 		$I->wantToTest( 'I want to manage my network sites.' );
 		$I->loginAsAdmin();
 
@@ -52,6 +54,8 @@ class SiteCest {
 		$this->logOut( $I );
 		$I->amOnPage( '/testsubdir/' );
 		$I->see( 'This site has been archived or suspended.' );
+
+		$I->wait(10); // wait for 10 seconds to avoid rate limiting.
 
 		// Mark a site as spam.
 		$I->loginAsAdmin();


### PR DESCRIPTION
- Fixes https://github.com/humanmade/product-dev/issues/1525, the issue were originally failing due to rate limiting on the NGINX server on local server and was returning 429 errors. This fix adds waits at different times to avoid the rate limiting.

###TESTS ON LOCAL

```
Acceptance Tests (2) ---------------------------------------
✔ SignupsCest: Test I want to manage my network signups. (14.03s)
✔ SiteCest: Test I want to manage my network sites. (43.03s)
------------------------------------------------------------


Time: 01:25.397, Memory: 22.00 MB

OK (2 tests, 3 assertions)
Flushing the cache...
Removing test databases..

What's next?
  Try Docker Debug for seamless, persistent debugging tools in any container or image → docker debug test-root-db
  Learn more at https://docs.docker.com/go/debug-cli/
Removing headless browser container..
```