### PR TITLE
Filter causes PHP Warning. Remove it.

### DIFF
--- a/inc/branding/namespace.php
+++ b/inc/branding/namespace.php
@@ -43,7 +43,6 @@ function bootstrap() {
 	add_filter( 'get_the_generator_rss2', __NAMESPACE__ . '\\override_generator', 10, 2 );
 	add_filter( 'get_the_generator_comment', __NAMESPACE__ . '\\override_generator', 10, 2 );
 	add_filter( 'get_the_generator_export', __NAMESPACE__ . '\\override_generator', 10, 2 );
-	add_filter( 'admin_bar_menu', __NAMESPACE__ . '\\remove_howdy_greeting', 25 );
 	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_block_editor_branding_assets' );
 	add_action( 'do_faviconico', __NAMESPACE__ . '\\override_default_favicon' );
 }
@@ -336,22 +335,6 @@ function override_generator( string $gen, string $type ) : string {
 				gmdate( 'Y-m-d H:i' )
 			);
 	}
-}
-
-/**
- * Remove the 'Howdy <name>' greeting in the admin bar.
- *
- * @param WP_Admin_Bar $wp_admin_bar Admin bar object.
- */
-function remove_howdy_greeting( WP_Admin_Bar $wp_admin_bar ) {
-	$acct_bar = $wp_admin_bar->get_node( 'my-account' );
-
-	$new_text = str_replace( 'Howdy,', 'Welcome,', $acct_bar->title );
-
-	$wp_admin_bar->add_node( [
-		'id' => 'my-account',
-		'title' => $new_text,
-	] );
 }
 
 /**


### PR DESCRIPTION
The "Howdy" greeting in the admin bar this filter is meant to replace is now set via JavaScript in the admin bar, so this no longer works. Instead, it generates a PHP warning because the title is null.

Addresses first par t of https://github.com/humanmade/product-dev/issues/1608
Relates to https://github.com/humanmade/product-dev/issues/1602
