### PR TITLE
Reformat docs files after linting

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,9 @@
 # CMS
 
-![](./assets/banner-cms.png)
+![CMS banner](./assets/banner-cms.png)
 
-The CMS (Content Management System) module is the foundational component of Altis. It provides the means of creating, editing and delivering your data.
+The CMS (Content Management System) module is the foundational component of Altis. It provides the means of creating, editing and
+delivering your data.
 
-The core experience is provided by [WordPress](https://wordpress.org/), with additional features tied in to create a smarter more fully featured CMS that's ready for enterprise.
+The core experience is provided by [WordPress](https://wordpress.org/), with additional features tied in to create a smarter more
+fully featured CMS that's ready for enterprise.

--- a/docs/block-editor.md
+++ b/docs/block-editor.md
@@ -9,21 +9,23 @@ WordPress's built in Reusable Blocks feature has been supercharged in Altis with
 * Provide a much more seamless implementation of reusable blocks into enterprise-level setups and workflows.
 * Provide an improved user interface that allows for better block discovery, including search and filtering.
 
-Within the block editor it's possible to reuse blocks of content across multiple posts or pages. In Altis these blocks can be more easily be created and managed from a single location and any updates will be reflected everywhere the block is used.
+Within the block editor it's possible to reuse blocks of content across multiple posts or pages. In Altis these blocks can be more
+easily be created and managed from a single location and any updates will be reflected everywhere the block is used.
 
-You can toggle these enhancements on or off in your `composer.json` file by setting the `reusable-blocks` property for the CMS module to `true` or `false`.
+You can toggle these enhancements on or off in your `composer.json` file by setting the `reusable-blocks` property for the CMS
+module to `true` or `false`.
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"cms": {
-					"reusable-blocks": false
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "cms": {
+                    "reusable-blocks": false
+                }
+            }
+        }
+    }
 }
 ```
 
@@ -33,17 +35,21 @@ Altis Reusable Blocks includes features and improvements both for the creation a
 
 #### Relationship and usage tracking
 
-Keep track of all usages of reusable blocks within your posts. Within the edit screen for your reusable blocks, you will find the Relationships sidebar with a paginated view of all the posts that are using the reusable block that you are currently editing.
+Keep track of all usages of reusable blocks within your posts. Within the edit screen for your reusable blocks, you will find the
+Relationships sidebar with a paginated view of all the posts that are using the reusable block that you are currently editing.
 
 On the reusable blocks post list table, you can see at a quick glance the usage count for that reusable block.
 
 #### Admin Bar and Menu
 
-By default, reusable blocks are somewhat hidden and can only be accessed from a submenu item in the block editor.
+By default, reusable blocks are somewhat hidden and can only be accessed from a sub-menu item in the block editor.
 With Altis Reusable Blocks, however, reusable blocks are upgraded to first-party citizens in the admin area.
 
-As with every other content type, the admin menu on the left contains a dedicated submenu for reusable blocks, offering shortcuts to see all existing reusable blocks, to create a new reusable block, and to see and manage categories, as well as any other publicly available taxonomy registered for reusable blocks.
-Also, the admin bar at the top now contains a shortcut to create a new reusable block, just like it is possible to do for posts, media, pages or users.
+As with every other content type, the admin menu on the left contains a dedicated sub-menu for reusable blocks, offering shortcuts
+to see all existing reusable blocks, to create a new reusable block, and to see and manage categories, as well as any other publicly
+available taxonomy registered for reusable blocks. Also, the admin bar at the top now contains a shortcut to create a new reusable
+block, just like it is possible to do for posts,
+media, pages or users.
 
 #### Categories
 
@@ -59,20 +65,19 @@ However, this can be changed, without affecting the post's categories.
 
 #### Search
 
-In addition to the Category filter, the block picker also provides a search field.
-The search query is used to find reusable blocks with either a matching title or content, or both.
-Search results are sorted based on a smart algorithm using different weights for title matches vs. content matches, and exact matches vs. partial matches.
-As a result, more relevant blocks are displayed first.
+In addition to the Category filter, the block picker also provides a search field. The search query is used to find reusable blocks
+with either a matching title or content, or both. Search results are sorted based on a smart algorithm using different weights for
+title matches vs. content matches, and exact matches vs. partial matches. As a result, more relevant blocks are displayed first.
 
-The search input also supports numeric ID lookups.
-By entering a block ID, the result set will be just that one according block, ready to be inserted.
-If the provided ID is a post ID, the results will be all reusable blocks referenced by that post, if any.
+The search input also supports looking up numeric IDs. By entering a block ID, the result set will be just that one according block,
+ready to be inserted. If the provided ID is a post ID, the results will be all reusable blocks referenced by that post, if any.
 
 ### PHP Filters
 
 #### `altis_post_types_with_reusable_blocks`
 
-This filter allows the user to manipulate the post types that can use reusable blocks and should have the relationship for the shadow taxonomy.
+This filter allows the user to manipulate the post types that can use reusable blocks and should have the relationship for the
+shadow taxonomy.
 
 **Arguments:**
 
@@ -84,9 +89,9 @@ This filter allows the user to manipulate the post types that can use reusable b
 // Add the "page" post type.
 add_filter( 'altis_post_types_with_reusable_blocks', function ( aray $post_types ): array {
 
-	$post_types[] = 'page';
+    $post_types[] = 'page';
 
-	return $post_types;
+    return $post_types;
 } );
 ```
 
@@ -104,14 +109,14 @@ This filter allows the user to modify the schema for the relationship data befor
 // Add the post author to the schema.
 add_filter( 'rest_get_relationship_item_additional_fields_schema', function ( array $additional_fields ): array {
 
-	$additional_fields['author'] = [
-		'description' => __( 'User ID for the author of the post.' ),
-		'type'        => 'integer',
-		'context'     => [ 'view' ],
-		'readonly'    => true,
-	];
+    $additional_fields['author'] = [
+        'description' => __( 'User ID for the author of the post.' ),
+        'type'        => 'integer',
+        'context'     => [ 'view' ],
+        'readonly'    => true,
+    ];
 
-	return $additional_fields;
+    return $additional_fields;
 } );
 ```
 
@@ -131,8 +136,8 @@ This filter allows the user to modify the relationship data right before it is r
 // Add the post author to the REST response.
 add_filter( 'rest_prepare_relationships_response', function ( WP_REST_Response $response, WP_Post $post ): WP_REST_Response {
 
-	$response->data['author'] = $post->post_author;
+    $response->data['author'] = $post->post_author;
 
-	return $response;
+    return $response;
 }, 10, 2 );
 ```

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -4,61 +4,74 @@ It's a common task to apply custom branding to match the site to various parts o
 
 ## Login screen
 
-You can change the logo shown on the CMS login screen using the `login-logo` configuration option to provide a project root relative path to an image file.
+You can change the logo shown on the CMS login screen using the `login-logo` configuration option to provide a project root relative
+path to an image file.
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"cms": {
-					"login-logo": "/content/site-logo.svg"
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "cms": {
+                    "login-logo": "/content/site-logo.svg"
+                }
+            }
+        }
+    }
 }
 ```
 
 ## Custom Admin Colour Scheme
 
-If the default colour scheme does not meet the accessibility needs of your staff you can register custom schemes to provide high contrast alternatives. To register a custom admin colour scheme add the following function on the `admin_init` action.
+If the default colour scheme does not meet the accessibility needs of your staff you can register custom schemes to provide high
+contrast alternatives. To register a custom admin colour scheme add the following function on the `admin_init` action.
 
 ```php
 wp_admin_css_color( string $key, string $name, string $url, array $colors = [], array $icons = [] );
 ```
+
 NB: note the American spelling of `color` in the function name.
+
+<!-- vale proselint.Spelling = NO -->
+
 - `key`: The unique key for this theme.
 - `name`: The name of the theme.
 - `url`: The URL of the CSS file containing the colour scheme.
-- `colors`: An array of CSS colour definition strings (hexadecimal format) which are used to give the user a feel for the theme. These colours are displayed in admin Users > Your Profile > Admin Color Scheme (if there are more than one available).
+- `colors`: An array of CSS colour definition strings (hexadecimal format) which are used to give the user a feel for the theme.
+  These colours are displayed in admin Users > Your Profile > Admin Color Scheme (if there are more than one available).
 - `icons`: CSS colour definitions (hexadecimal format) used to colour any SVG icons.
   - `base`: SVG icon base colour, in hexadecimal format.
   - `focus`: SVG icon colour on focus, in hexadecimal format.
   - `current`: SVG icon colour of current admin menu link, in hexadecimal format.
 
+<!-- vale proselint.Spelling = YES -->
+
 Example:
+
 ```php
 add_action( 'admin_init', 'add_colour_scheme' );
 function add_colour_scheme() {
-	wp_admin_css_color(
-			'dusk',
-			_x( 'Dusk', 'admin colour scheme' ),
-			admin_url( "path/to/css/file/dusk.css" ),
-			[ '#25282b', '#363b3f', '#69a8bb', '#e14d43' ],
-			[
-				'base'    => '#f1f2f3',
-				'focus'   => '#fff',
-				'current' => '#fff',
-			]
-	);
+    wp_admin_css_color(
+            'dusk',
+            _x( 'Dusk', 'admin colour scheme' ),
+            admin_url( "path/to/css/file/dusk.css" ),
+            [ '#25282b', '#363b3f', '#69a8bb', '#e14d43' ],
+            [
+                'base'    => '#f1f2f3',
+                'focus'   => '#fff',
+                'current' => '#fff',
+            ]
+    );
 }
 ```
 
-## Custom Favicon
-The favicon shown for the application can be set using either the CMS or a configuration option. Using the CMS option will override the configuration option.
+## Custom `favicon`
+
+The favicon shown for the application can be set using either the CMS or a configuration option. Using the CMS option will override
+the configuration option.
 
 ### CMS Option
+
 1. Login to the admin area
 2. Go to **Appearance** > **Customize** and click on the **Site Identity** tab
 3. Scroll to **Site Icon** and click on the select site icon button, then upload the image you want to use as the icon.
@@ -66,18 +79,19 @@ The favicon shown for the application can be set using either the CMS or a confi
 5. Publish your changes.
 
 ### Configuration Option
+
 You can use the `favicon` configuration option to provide a project root relative path to an image file.
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"cms": {
-					"favicon": "/content/favicon.png"
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "cms": {
+                    "favicon": "/content/favicon.png"
+                }
+            }
+        }
+    }
 }
 ```

--- a/docs/full-site-editing.md
+++ b/docs/full-site-editing.md
@@ -1,14 +1,17 @@
 # Full Site Editing
 
-With the introduction of WordPress 5.9 the block editor can now be used to edit the entire website, including the header, navigation menus, sidebars, footer and layouts.
+With the introduction of WordPress 5.9 the block editor can now be used to edit the entire website, including the header, navigation
+menus, sidebars, footer and layouts.
 
-This is achieved with a new type of theme called a Block Theme. The core difference between classic themes and block themes is that your template files are HTML rather than PHP, containing a combination of raw HTML and block editor comments.
+This is achieved with a new type of theme called a Block Theme. The core difference between classic themes and block themes is that
+your template files are HTML rather than PHP, containing a combination of raw HTML and block editor comments.
 
 [For a more in depth overview and comparison to classic themes see the WordPress Theme Handbook](https://developer.wordpress.org/themes/block-themes/).
 
 ## Enabling FSE
 
-To add Full Site Editing (FSE) support to a theme, and make it a Block Theme, you will need an `index.html` file in a directory called `templates`. The file does not need to contain any code.
+To add Full Site Editing (FSE) support to a theme, and make it a Block Theme, you will need an `index.html` file in a directory
+called `templates`. The file does not need to contain any code.
 
 This is in addition to the classic theme minimum requirements of an `index.php` file and a `style.css` file.
 
@@ -16,40 +19,46 @@ This is in addition to the classic theme minimum requirements of an `index.php` 
 
 ### Block Theme Templates
 
-In the same way a classic theme uses specific files like `single.php`, and `404.php` for different page templates, WordPress will look for and load the corresponding HTML templates in an FSE theme, so you would have the files `templates/single.html`, `templates/404.html` and so on. These take precendence over any matching PHP templates.
+In the same way a classic theme uses specific files like `single.php`, and `404.php` for different page templates, WordPress will
+look for and load the corresponding HTML templates in an FSE theme, so you would have the files `templates/single.html`,
+`templates/404.html` and so on. These take precedence over any matching PHP templates.
 
-In block themes the `<head>` and `<body>` elements are added for you. Necessary PHP hooks that you would add to a classic theme, including `wp_head()`, `wp_body_open()`, and `wp_footer()`, are also added automatically. The markup that is inside the template file is printed between the opening and closing body tags.
+In block themes the `<head>` and `<body>` elements are added for you. Necessary PHP hooks that you would add to a classic theme,
+including `wp_head()`, `wp_body_open()`, and `wp_footer()`, are also added automatically. The markup that is inside the template
+file is printed between the opening and closing body tags.
 
 ### Site Editor
 
 ![FSE Site Editor](./assets/site-editor.png)
 
-HTML templates can be created in code or by using the new Site Editor in the WordPress admin. Templates created in code serve as the default configuration for a template and can be modified in the Site Editor. The Site Editor can even be used to create the templates, and then the code can be copied into the HTML template files rather than having to hand code them.
+HTML templates can be created in code or by using the new Site Editor in the WordPress admin. Templates created in code serve as the
+default configuration for a template and can be modified in the Site Editor. The Site Editor can even be used to create the
+templates, and then the code can be copied into the HTML template files rather than having to hand code them.
 
 [Learn how to create or edit existing themes in the Site Editor here](https://developer.wordpress.org/themes/block-themes/creating-new-themes-using-the-site-editor/).
 
 ### Example Block Theme File Structure
 
-```
+```text
 assets (dir)
-      - css (dir)
-            - blocks (dir)
-      - images (dir)
-      - js (dir)
-inc (dir)
+    - css (dir)
       - blocks (dir)
+    - images (dir)
+    - js (dir)
+inc (dir)
+    - blocks (dir)
 patterns (dir)
-      - author-credit.php
+    - author-credit.php
 parts (dir)
-      - footer.html
-      - header.html
+    - footer.html
+    - header.html
 templates (dir)
-      - 404.html
-      - archive.html
-      - index.html
-      - page.html
-      - single.html
-      - search.html
+    - 404.html
+    - archive.html
+    - index.html
+    - page.html
+    - single.html
+    - search.html
 functions.php
 index.php
 style.css
@@ -59,7 +68,8 @@ theme.json
 
 ### Template Parts
 
-In addition to `templates` that are used for the layout of entire pages, block themes can use the new Template Part block to include reusable partial templates. These must be placed in the `parts` directory.
+In addition to `templates` that are used for the layout of entire pages, block themes can use the new Template Part block to include
+reusable partial templates. These must be placed in the `parts` directory.
 
 For example `parts/header.html` may look like this:
 
@@ -87,16 +97,18 @@ To make template parts available to use in the block editor they need to be regi
 }
 ```
 
-The `name` corresponds to the file name, `title` is a human-readable title for the part and `area` denotes where the template part can go, one of `header`, `general` and `footer`.
+The `name` corresponds to the file name, `title` is a human-readable title for the part and `area` denotes where the template part
+can go, one of `header`, `general` and `footer`.
 
 [You can find further reading about Template Parts here](https://developer.wordpress.org/themes/block-themes/templates-and-template-parts/).
 
-
 ### Block Patterns
 
-Block Patterns allow you to create reusable patterns of blocks that do not need to be created as reusable blocks in the admin. They are similar to template parts but can be used in any block editor context, template part or template.
+Block Patterns allow you to create reusable patterns of blocks that do not need to be created as reusable blocks in the admin. They
+are similar to template parts but can be used in any block editor context, template part or template.
 
-Using Block Patterns is necessary to provide translatable text in HTML templates, they can be included using the core pattern block like so:
+Using Block Patterns is necessary to provide translatable text in HTML templates, they can be included using the core pattern block
+like so:
 
 ```html
 <!-- wp:core/pattern {"slug":"my-theme/author-credit"} -->
@@ -129,24 +141,24 @@ function register() {
 
 [Read more about block patterns on the Block Editor Handbook](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-patterns/).
 
-
 ### Theme Blocks
 
-Block Themes can use additional core blocks that map to classic functionality like `the_title()` and `the_content()` functions, for example `<!-- wp:post-title /-->` and `<!-- wp:post-content /-->`.
+Block Themes can use additional core blocks that map to classic functionality like `the_title()` and `the_content()` functions, for
+example `<!-- wp:post-title /-->` and `<!-- wp:post-content /-->`.
 
-An important combination of theme blocks is the Query Block and Post Template. These provide context to the blocks nested within them, allowing you to use the loop within HTML templates, for example:
+An important combination of theme blocks is the Query Block and Post Template. These provide context to the blocks nested within
+them, allowing you to use the loop within HTML templates, for example:
 
 ```html
 <!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post"}} -->
-    <!-- wp:post-template -->
-        <!-- wp:post-title {"isLink":true} /-->
-        <!-- wp:post-excerpt /-->
-    <!-- /wp:post-template -->
+<!-- wp:post-template -->
+<!-- wp:post-title {"isLink":true} /-->
+<!-- wp:post-excerpt /-->
+<!-- /wp:post-template -->
 <!-- /wp:query -->
 ```
 
 [The full core block reference can be found here](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/).
-
 
 ## Resources
 
@@ -154,7 +166,9 @@ An important combination of theme blocks is the Query Block and Post Template. T
 
 You can experiment with FSE by installing and looking at existing examples:
 
+<!-- vale Vale.Repetition = NO -->
 - [Twenty Twenty Two Theme](https://en-gb.wordpress.org/themes/twentytwentytwo/): the new default theme with FSE support
+<!-- vale Vale.Repetition = YES -->
 - [Empty Theme](https://github.com/WordPress/theme-experiments/tree/master/emptytheme): a sample empty theme to start building from
 - [Full Site Editing tag on WordPress.org themes repository](https://en-gb.wordpress.org/themes/tags/full-site-editing/)
 

--- a/docs/helper-functions.md
+++ b/docs/helper-functions.md
@@ -1,29 +1,30 @@
 # Helper Functions
 
-## `clean_html( string $text, array $allowedtags = [], string $context = '' ) : string`
+## Function `clean_html`
 
-When translating strings in WordPress, the most common functions to use are `__()` (translate and return) or `_e()` (translate and output). Where possible, these need to be escaped too, to ensure that translations don't accidentally break your output. For this reason, `esc_html_e()`, `esc_attr_e()`, etc are offered by WordPress as convenience functions.
+```php
+function clean_html( string $text, array $allowedtags = [], string $context = '' ) : string
+```
+
+When translating strings in WordPress, the most common functions to use are `__()` (translate and return) or `_e()` (translate and
+output). Where possible, these need to be escaped too, to ensure that translations don't accidentally break your output. For this
+reason, `esc_html_e()`, `esc_attr_e()`, etc. are offered by WordPress as convenience functions.
 
 However, this falls down when you need to have HTML in the translation.
 
-This function provides a nice, easy, performant way to perform sanitization on translated strings. Rather than requiring you to work with the internals of kses, it's much closer to functions like `esc_html()`.
+This function provides a nice, easy, quick way to perform sanitization on translated strings. Rather than requiring you to work with
+the internals of `kses`, it's much closer to functions like `esc_html()`.
 
 ### Parameters
 
-**`$text`**
-
-_(string)(required)_ Content to escape
-
-**`$allowedtags`**
-
-_(array)_ Allowed tags, see examples.
-
-**`$context`**
-
-_(string)_ kses context to use (see [wp_kses_allowed_html](http://developer.wordpress.org/reference/functions/wp_kses_allowed_html/))
+- `$text` _(string)(required)_ Content to escape
+- `$allowedtags`  _(array)_ Allowed tags, see examples.
+- `$context`  _(string)_ `kses` context to use (
+  see [`wp_kses_allowed_html`](http://developer.wordpress.org/reference/functions/wp_kses_allowed_html/))
 
 ### Return
-_(string)_ Escaped string for output into HTML context.
+
+- _(string)_ Escaped string for output into HTML context.
 
 ### Example usage
 
@@ -33,117 +34,123 @@ To allow `a` tags only in a translated string:
 
 ```php
 $text = clean_html(
-	sprintf(
-		__( 'This is some text <a href="%1$s">with a link</a>'),
-		'http://example.com/'
-	),
-	'a'
+    sprintf(
+        __( 'This is some text <a href="%1$s">with a link</a>'),
+        'http://example.com/'
+    ),
+    'a'
 );
 ```
+
 It works with multiple elements as well, using a comma-separated string or list of elements:
 
 ```php
 $text = clean_html(
-	sprintf(
-		__( 'This is <code>some</code> text <a href="%1$s">with a link</a>'),
-		'http://example.com/'
-	),
-	'a, code' // or [ 'a', 'code' ]
+    sprintf(
+        __( 'This is <code>some</code> text <a href="%1$s">with a link</a>'),
+        'http://example.com/'
+    ),
+    'a, code' // or [ 'a', 'code' ]
 );
 ```
-If you need custom attributes, you can use kses-style attribute specifiers.
-These can be mixed too:
+
+If you need custom attributes, you can use kses-style attribute specifiers. These can be mixed too:
 
 ```php
 $text = clean_html(
-	sprintf(
-		__( 'This is <span class="x">some</span> text <a href="%1$s">with a link</a>'),
-		'http://example.com/'
-	),
-	[
-		'a',
-		'span' => [
-			'class' => true,
-		],
-	]
+    sprintf(
+        __( 'This is <span class="x">some</span> text <a href="%1$s">with a link</a>'),
+        'http://example.com/'
+    ),
+    [
+        'a',
+        'span' => [
+            'class' => true,
+        ],
+    ]
 );
 ```
 
-## `print_clean_html( string $text, array $allowedtags = [], string $context = '' ) : void`
+## Function `print_clean_html`
+
+```php
+print_clean_html( string $text, array $allowedtags = [], string $context = '' ) : void
+```
 
 Equivalent of `clean_html()` which echoes output directly rather than returning.
 
 ### Parameters
 
-**`$text`**
-
-_(string)(required)_ Content to escape
-
-**`$allowedtags`**
-
-_(array)_ Allowed tags, see examples under `clean_html`.
-
-**`$context`**
-
-_(string)_ kses context to use (see [wp_kses_allowed_html](http://developer.wordpress.org/reference/functions/wp_kses_allowed_html/))
+- `$text` _(string)(required)_ Content to escape
+- `$allowedtags`  _(array)_ Allowed tags, see examples under `clean_html`.
+- `$context`  _(string)_ `kses` context to use (
+  see [`wp_kses_allowed_html`](http://developer.wordpress.org/reference/functions/wp_kses_allowed_html/))
 
 ### Return
-_(void)_ Escaped string is echoed to the browser directly.
 
-## `wp_hash_password( string $password )`
+- _(void)_ Escaped string is echoed to the browser directly.
 
-Hash password using bcrypt. This function calls `password_hash` instead of WP's default password hasher.
+## Function `wp_hash_password`
 
-The `wp_hash_password_options` filter is available to set the [options](http://php.net/manual/en/function.password-hash.php) that `password_hash` can accept.
+```php
+wp_hash_password( string $password ) : bool|string
+```
+
+Hash password using bcrypt. This function calls `password_hash` instead of WordPress' default password hashing function.
+
+The `wp_hash_password_options` filter is available to set the [options](http://php.net/manual/en/function.password-hash.php) that
+`password_hash` can accept.
 
 ### Parameters
 
-**`$password`**
-
-_(string)(required)_ Plaintext password
+- `$password` _(string)(required)_ Plaintext password
 
 ### Return
-_(bool|string)_
 
-## `wp_check_password( string $password, string $hash, int|string $userId )`
+- _(bool|string)_
 
-Check if user has entered correct password, supports bcrypt and pHash.
+## Function `wp_check_password`
 
-At its core, this function just calls `password_verify` instead of the default.
-However, it also checks if a user's password was *previously* hashed with the old MD5-based hasher and re-hashes it with bcrypt. This means you can still install this plugin on an existing site and everything will work seamlessly.
+```php
+wp_check_password( string $password, string $hash, int|string $userId ) : mixed|void
+```
+
+Check if user has entered correct password, supports `bcrypt` and `pHash`.
+
+At its core, this function just calls `password_verify` instead of the default. However, it also checks if a user's password was
+_previously_ hashed with the old MD5-based hash function and re-hashes it with bcrypt. This means you can still install this plugin
+on an existing site and everything will work seamlessly.
 
 The `check_password` filter is available just like the default WP function.
 
 ### Parameters
 
-**`$password`**
-
-_(string)(required)_ Plaintext password
-
-**`$hash`**
-
-_(string)(required)_ Hash of password
-
-**`$userId`**
-
-_(int|string)_ ID of user to whom the password belongs
+- `$password` _(string)(required)_ Plaintext password
+- `$hash` _(string)(required)_ Hash of password
+- `$userId`   _(int|string)_ ID of user to whom the password belongs
 
 ### Return
-_(mixed|void)_
 
-## `wp_set_password( string $password, int $userId )`
+- _(mixed|void)_
+
+## Function `wp_set_password`
+
+```php
+wp_set_password( string $password, int $userId ) : bool|string
+```
 
 Set password using bcrypt.
 
-This function is included here verbatim but with the addition of returning the hash. The default WP function does not return anything which means you end up hashing it twice for no reason.
+This function is included here verbatim but with the addition of returning the hash. The default WP function does not return
+anything which means you end up hashing it twice for no reason.
 
 ### Parameters
 
-**`$password`**
-_(string)(required)_ Plaintext password
-
-**`$userId`**
-_(int)(required)_ ID of user to whom password belongs
+- `$password` _(string)(required)_ Plaintext password
+- `$userId` _(int)(required)_ ID of user to whom password belongs
 
 ### Return
-_(bool|string)_
+
+- _(bool|string)_
+
+<!-- markdownlint-disable-file MD024 -->

--- a/docs/local-avatars.md
+++ b/docs/local-avatars.md
@@ -1,18 +1,22 @@
 # Local Avatars
 
-Altis provides a way to customize your profile picture via the [Simple Local Avatars](https://github.com/10up/simple-local-avatars) plugin. By default, a [Gravatar](https://en.gravatar.com/) will be used to fetch your profile picture. However, if you don't have an existing Gravatar, and have no desire to create one, you can use any image uploaded to the media library -- or upload a new image -- and set that as your profile picture or "avatar".
+Altis provides a way to customize your profile picture via the [Simple Local Avatars](https://github.com/10up/simple-local-avatars)
+plugin. By default, a [Gravatar](https://en.gravatar.com/) will be used to fetch your profile picture. However, if you don't have an
+existing Gravatar, and have no desire to create one, you can use any image uploaded to the media library — or upload a new
+image — and set that as your profile picture or "avatar".
 
-By default, local avatars is enabled and the default profile picture field on the Edit Profile page is hidden. However, this can be disabled and the default functionality restored by updating your Altis config:
+By default, local avatars is enabled and the default profile picture field on the Edit Profile page is hidden. However, this can be
+disabled and the default functionality restored by updating your Altis config:
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"cms": {
-				"local-avatars": false
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "cms": {
+                "local-avatars": false
+            }
+        }
+    }
 }
 ```
 
@@ -20,13 +24,13 @@ By default, local avatars is enabled and the default profile picture field on th
 
 ### `simple_local_avatars_dynamic_resize`
 
-Allows automatic rescaling to be turned off. 
+Allows automatic rescaling to be turned off.
 
-**Parameters**
+### Parameters
 
-**`$allow_resize`** _(bool)_ Whether to allow dynamic resizing.
+- `$allow_resize` _(bool)_ Whether to allow dynamic resizing.
 
-**Example**
+### Example
 
 ```php
 add_filter( 'simple_local_avatars_dynamic_resize', '__return_false' );
@@ -36,14 +40,16 @@ add_filter( 'simple_local_avatars_dynamic_resize', '__return_false' );
 
 Allows overriding of the maximum allowable file size for avatar uploads. Defaults to the WordPress maximum default upload size.
 
-**Parameters**
+### Parameters
 
-**`$bytes`** _(int)_ The maximum byte size.
+- `$bytes` _(int)_ The maximum byte size.
 
-**Example**
+### Example
 
 ```php
 add_filter( 'simple_local_avatars_upload_limit', function() {
-	return 2 * 1024 * 1024; // Max 2MB.
+    return 2 * 1024 * 1024; // Max 2MB.
 } );
 ```
+
+<!-- markdownlint-disable-file MD024 -->

--- a/docs/permalinks.md
+++ b/docs/permalinks.md
@@ -1,6 +1,8 @@
 # Permalinks
 
-Altis introduces a fix to a bug where the main site on a network is hardcoded to contain `/blog/` prefix for posts by default. The side-effect for this is that you cannot use `/blog/` prefix on the main site unless you disable the fix, which is by unhooking the filters associated with it, eg:
+Altis introduces a fix to a bug where the main site on a network is hard-coded to contain `/blog/` prefix for posts by default. The
+side-effect for this is that you cannot use `/blog/` prefix on the main site unless you disable the fix, which is by unhooking the
+filters associated with it, e.g.:
 
 ```php
 add_action( 'plugins_loaded', function () {
@@ -9,4 +11,5 @@ add_action( 'plugins_loaded', function () {
 } );
 ```
 
-Note that the prefix will always be used by the main site now, regardless of what permalink structure you choose in settings, in other terms, you don't need to add the `/blog/` prefix to the custom permalink structure, or you'll have it duplicated in the URL.
+Note that the prefix will always be used by the main site now, regardless of what permalink structure you choose in settings, in
+other terms, you don't need to add the `/blog/` prefix to the custom permalink structure, or you'll have it duplicated in the URL.

--- a/docs/rss.md
+++ b/docs/rss.md
@@ -1,21 +1,23 @@
 # RSS Feeds
 
-RSS Feeds ("Rich Site Summary" or "Really Simple Syndication"), Atom or RDF are type of web feeds that provides users and applications with regular updates from a given website. The RSS feed is a structured XML code document. 
+RSS Feeds ("Rich Site Summary" or "Really Simple Syndication"), Atom or RDF are type of web feeds that provides users and
+applications with regular updates from a given website. The RSS feed is a structured XML code document.
 
 By default the RSS Feeds are enabled. If you wish to disable it, set the `feeds` configuration property to `false`
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"cms": {
-					"feeds": false
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "cms": {
+                    "feeds": false
+                }
+            }
+        }
+    }
 }
 ```
 
-For more information on RSS feeds, please see the [WordPress RSS documentation](https://wordpress.org/support/article/wordpress-feeds/).
+For more information on RSS feeds, please see
+the [WordPress RSS documentation](https://wordpress.org/support/article/wordpress-feeds/).

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,26 +1,29 @@
 # Themes
 
-Themes are used to control the visual style of your sites. Themes can be shared and reused across many sites in a project, and you can also create "child" themes which inherit parts of another theme.
+Themes are used to control the visual style of your sites. Themes can be shared and reused across many sites in a project, and you
+can also create "child" themes which inherit parts of another theme.
 
-Themes are a core concept of WordPress, the underlying implementation of the CMS module. For further documentation, consult the [WordPress theme documentation](https://developer.wordpress.org/themes/).
+Themes are a core concept of WordPress, the underlying implementation of the CMS module. For further documentation, consult
+the [WordPress theme documentation](https://developer.wordpress.org/themes/).
 
 See the [first theme guide](docs://getting-started/first-theme.md) for more information on creating new themes.
 
-
 ## Default theme
 
-When a [new site](docs://guides/multiple-sites.md) is created, a "default" theme is activated. Out of the box, this is set to the `base` starter theme included with Altis, but this can be changed by setting the `default-theme` option. This should be set to the directory name of the theme.
+When a [new site](docs://guides/multiple-sites.md) is created, a "default" theme is activated. Out of the box, this is set to the
+`base` starter theme included with Altis, but this can be changed by setting the `default-theme` option. This should be set to the
+directory name of the theme.
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"cms": {
-					"default-theme": "twentynineteen"
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "cms": {
+                    "default-theme": "twentynineteen"
+                }
+            }
+        }
+    }
 }
 ```

--- a/docs/xmlrpc.md
+++ b/docs/xmlrpc.md
@@ -8,14 +8,14 @@ By default XML RPC is enabled. If you wish to disable it, set the `xmlrpc` confi
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"cms": {
-					"xmlrpc": false
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "cms": {
+                    "xmlrpc": false
+                }
+            }
+        }
+    }
 }
 ```


### PR DESCRIPTION
This changes all the docs files to be formatted correctly after linting. The main changes are line length, spaces instead of tabs, and addition of alt text for images. Some grammar and spelling issues were also fixed.

Resolves https://github.com/humanmade/altis-cms/issues/676