### PR TITLE
Upgrade WordPress to 6.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=7.1",
     "stuttter/wp-user-signups": "^5.0.2",
     "roots/wp-password-bcrypt": "1.2.0",
-    "johnpbloch/wordpress": "6.6.2",
+    "johnpbloch/wordpress": "6.7.0",
     "altis/cms-installer": "^0.4.4",
     "humanmade/clean-html": "^2.0.0",
     "humanmade/altis-reusable-blocks": "~0.2.4",


### PR DESCRIPTION
Upgrade WordPress to version 6.7.0

Addresses https://github.com/humanmade/product-dev/issues/1619
