### PR TITLE
Upgrade to WordPress 6.7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=7.1",
     "stuttter/wp-user-signups": "^5.0.2",
     "roots/wp-password-bcrypt": "1.2.0",
-    "johnpbloch/wordpress": "6.7.0",
+    "johnpbloch/wordpress": "6.7.1",
     "altis/cms-installer": "^0.4.4",
     "humanmade/clean-html": "^2.0.0",
     "humanmade/altis-reusable-blocks": "~0.2.4",


### PR DESCRIPTION
Upgrades the WordPress package to 6.7.1