### PR TITLE
Update the minimum PHP version to 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=8.2",
     "stuttter/wp-user-signups": "^5.0.2",
     "roots/wp-password-bcrypt": "1.2.0",
     "johnpbloch/wordpress": "6.7.2",


### PR DESCRIPTION
Update the minimum PHP version to that which Altis supports. This will allow dependabot to run successfully.

Addresses: humanmade/product-dev#1735