### PR TITLE
Upgrade to WordPress 6.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
   "require": {
     "php": ">=8.2",
     "stuttter/wp-user-signups": "^5.0.2",
-    "roots/wp-password-bcrypt": "1.2.0",
-    "johnpbloch/wordpress": "6.7.2",
+    "johnpbloch/wordpress": "6.8.0",
     "altis/cms-installer": "^0.4.4",
     "humanmade/clean-html": "^2.0.0",
     "humanmade/altis-reusable-blocks": "~0.2.4",


### PR DESCRIPTION
Upgrades to use WordPress 6.8
Also removed the `roots/wp-password-bcrypt` library as it is no longer needed.

Addresses: https://github.com/humanmade/product-dev/issues/1768