### PR TITLE
Fix broken test.

### DIFF
--- a/tests/acceptance/SitesCest.php
+++ b/tests/acceptance/SitesCest.php
@@ -25,7 +25,7 @@ class SiteCest {
 		$I->amOnAdminPage( 'network/site-new.php' );
 		$I->fillField( '#site-address', 'testsubdom' );
 		$I->fillField( '#site-title', 'Test Subdomain Site' );
-		$I->click( 'Add Site' );
+		$I->click('#add-site');  // instead of $I->click('Add Site'); which clashes wih the hidden menu item of the same name.
 		$I->waitForText( 'Site added.' );
 
 		// Add a new site as subdirectory.
@@ -33,7 +33,7 @@ class SiteCest {
 		$I->fillField( '#site-address', 'testsubdir' );
 		$I->fillField( '#site-title', 'Test Subdirectory Site' );
 		$I->click( '#site-subdirectory' );
-		$I->click( 'Add Site' );
+		$I->click('#add-site');  // instead of $I->click('Add Site');
 		$I->waitForText( 'Site added.' );
 
 		// Test both sites are accessible, as well as their dashboards.

--- a/tests/acceptance/SitesCest.php
+++ b/tests/acceptance/SitesCest.php
@@ -25,7 +25,7 @@ class SiteCest {
 		$I->amOnAdminPage( 'network/site-new.php' );
 		$I->fillField( '#site-address', 'testsubdom' );
 		$I->fillField( '#site-title', 'Test Subdomain Site' );
-		$I->click('#add-site');  // instead of $I->click('Add Site'); which clashes wih the hidden menu item of the same name.
+		$I->click( '#add-site' );  // instead of $I->click('Add Site'); which clashes wih the hidden menu item of the same name.
 		$I->waitForText( 'Site added.' );
 
 		// Add a new site as subdirectory.
@@ -33,7 +33,7 @@ class SiteCest {
 		$I->fillField( '#site-address', 'testsubdir' );
 		$I->fillField( '#site-title', 'Test Subdirectory Site' );
 		$I->click( '#site-subdirectory' );
-		$I->click('#add-site');  // instead of $I->click('Add Site');
+		$I->click( '#add-site' );  // instead of $I->click('Add Site');.
 		$I->waitForText( 'Site added.' );
 
 		// Test both sites are accessible, as well as their dashboards.


### PR DESCRIPTION
The search for "Add Site" to click finds the menu item first. But is is hidden because the menu is not expanded on the small screen size the tests run under. Changed the test to use the unique ID the button has.

<img width="990" height="549" alt="CleanShot 2026-01-29 at 16 52 42" src="https://github.com/user-attachments/assets/c35cb844-5c5f-4090-b273-c067dcea35b9" />

During the test, the menu is not visible
<img width="800" height="600" alt="SiteCest testSitesManagementActions fail" src="https://github.com/user-attachments/assets/03bc9974-713e-40ee-a34e-aaceba1d62c2" />
So the code can't "click" it.

- Fixes https://github.com/humanmade/product-dev/issues/1815