### PR TITLE
Skip password reset redirect when activating signups in admin

### DIFF
--- a/inc/signup_notification/namespace.php
+++ b/inc/signup_notification/namespace.php
@@ -539,6 +539,13 @@ function altis_welcome_user_notification( $user_id, $password, $meta = [] ) {
  * @param array  $meta     Signup meta data.
  */
 function redirect_to_password_reset( $user_id, $password, $meta ) {
+	// Only redirect in the public activation flow (wp-activate.php). When a
+	// network admin activates a signup from the admin list, leave the admin
+	// flow alone so the "Activated <email>" notice renders.
+	if ( is_admin() ) {
+		return;
+	}
+
 	$user = get_userdata( $user_id );
 	if ( ! $user ) {
 		return;
@@ -579,6 +586,13 @@ function redirect_to_password_reset( $user_id, $password, $meta ) {
  * @param array  $meta     Signup meta data.
  */
 function redirect_blog_user_to_password_reset( $blog_id, $user_id, $password, $title, $meta ) {
+	// Only redirect in the public activation flow (wp-activate.php). When a
+	// network admin activates a signup from the admin list, leave the admin
+	// flow alone so the "Activated <email>" notice renders.
+	if ( is_admin() ) {
+		return;
+	}
+
 	$user = get_userdata( $user_id );
 	if ( ! $user ) {
 		return;


### PR DESCRIPTION
## Summary
- Skip the post-activation password reset redirect (added in 264f061 for #2009) when in admin context.
- Restores the network-admin signups "Activate" flow so the "Activated <email>" notice renders.
- The wp-activate.php public flow that #2009 actually targets is unaffected.

## Background
264f061 added hooks on `wpmu_activate_user` and `wpmu_activate_blog` that call `wp_safe_redirect()` to the password reset page after activation. These fire for any caller of `wpmu_activate_signup()` — including the wp-user-signups admin list table — so a network admin clicking "Activate" was being redirected away from the admin page before `wp_signups_handle_actions()` could redirect back to the list with the success notice. This was caught by `SignupsCest::testSitesManagementActions` in product-dev nightly CI ([run 25669000209](https://github.com/humanmade/product-dev/actions/runs/25669000209)).

## Test plan
- [x] `composer dev-tools codecept run -p vendor/altis/cms/tests/ -- acceptance SignupsCest` passes locally.
- [ ] Manual: confirm a new signup via the email activation link → still redirects to wp-login.php password reset (issue #2009 behaviour preserved).
- [ ] Manual: in Network Admin → Signups, click "Activate" on a pending signup → lands back on the signups list with "Activated <email>" notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)