### PR TITLE
Relax humanmade/asset-loader constraint to allow ^0.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "altis/cms-installer": "^0.4.4",
     "humanmade/clean-html": "^2.0.0",
     "humanmade/altis-reusable-blocks": "~0.2.4",
-    "humanmade/asset-loader": "^0.6.4",
+    "humanmade/asset-loader": "^0.6.4 || ^0.8.0",
     "10up/simple-local-avatars": "~2.7.11"
   },
   "autoload": {


### PR DESCRIPTION
Allow ^0.8.0 of humanmade/asset-loader so projects can use the new utility functions added in 0.7/0.8. Refs #941.

Altis itself doesn't call any of asset-loader's public functions — it just makes the plugin available. And 0.8.0 keeps the deprecated names working.