### PR TITLE
Update wordpress 6.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": ">=8.2",
     "stuttter/wp-user-signups": "^5.0.2",
-    "johnpbloch/wordpress": "6.9.6",
+    "johnpbloch/wordpress": "6.9.7",
     "altis/cms-installer": "^0.4.4",
     "humanmade/clean-html": "^2.0.0",
     "humanmade/altis-reusable-blocks": "~0.2.4",


### PR DESCRIPTION
Updates WordPress to 6.9.7