### PR TITLE
Use the PSR-4 IdnaEncoder class name

### DIFF
--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -7,7 +7,7 @@
 
 namespace Altis\CMS\Add_Site_UI;
 
-use Requests_IDNAEncoder;
+use WpOrg\Requests\IdnaEncoder;
 
 const REGEX_DOMAIN_SEGMENT = '(?![0-9]+$)(?!.*-$)(?!-)[a-zA-Z0-9-]{1,63}';
 
@@ -214,17 +214,17 @@ function validate_domain_segment( string $segment ) : bool {
 /**
  * Encode a URL string with the IDNA encoder
  *
- * @see https://developer.wordpress.org/reference/classes/requests_idnaencoder/
+ * @see https://developer.wordpress.org/reference/classes/wporg-requests-idnaencoder/
  * @see https://tools.ietf.org/html/rfc3490
  *
- * @uses https://developer.wordpress.org/reference/classes/requests_idnaencoder/encode/
+ * @uses https://developer.wordpress.org/reference/classes/wporg-requests-idnaencoder/encode/
  *
  * @param string $url A URL domain string to encode.
  *
  * @return string The encoded string.
  */
 function idna_encode( string $url ) : string {
-	return Requests_IDNAEncoder::encode( $url );
+	return IdnaEncoder::encode( $url );
 }
 
 /**

--- a/tests/integration.suite.yml
+++ b/tests/integration.suite.yml
@@ -1,0 +1,9 @@
+# Codeception Test Suite Configuration
+#
+# Suite for unit or integration tests that require WordPress functions and classes.
+
+actor: IntegrationTester
+modules:
+    enabled:
+        - WPLoader
+        - \Helper\Integration

--- a/tests/integration/add-site-ui/IdnaEncodeTest.php
+++ b/tests/integration/add-site-ui/IdnaEncodeTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Test the Add Site UI IDNA encoder.
+ *
+ * phpcs:disable WordPress.Files, HM.Files, HM.Functions.NamespacedFunctions, WordPress.NamingConventions
+ */
+
+namespace AddSiteUI;
+
+use function Altis\CMS\Add_Site_UI\idna_encode;
+
+/**
+ * Test the Add Site UI IDNA encoder.
+ */
+class IdnaEncodeTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * Tester
+	 *
+	 * @var \IntegrationTester
+	 */
+	protected $tester;
+
+	/**
+	 * Domains and their expected punycode encoding.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function domainProvider() : array {
+		return [
+			'non-ascii domain' => [ 'exämple.com', 'xn--exmple-cua.com' ],
+			'multiple non-ascii labels' => [ 'täst.münchen.de', 'xn--tst-qla.xn--mnchen-3ya.de' ],
+			'plain ascii passes through' => [ 'example.com', 'example.com' ],
+			'already punycode passes through' => [ 'xn--exmple-cua.com', 'xn--exmple-cua.com' ],
+			'ascii case is preserved' => [ 'ALLCAPS.com', 'ALLCAPS.com' ],
+		];
+	}
+
+	/**
+	 * Test that domains are encoded to punycode.
+	 *
+	 * The implementation moved from the PSR-0 `Requests_IDNAEncoder` alias to the
+	 * PSR-4 `WpOrg\Requests\IdnaEncoder` class it points at. These expectations
+	 * are the values the PSR-0 name produced, so they pin the swap to identical
+	 * output.
+	 *
+	 * @dataProvider domainProvider
+	 *
+	 * @param string $domain   The domain to encode.
+	 * @param string $expected The expected encoded domain.
+	 *
+	 * @return void
+	 */
+	public function testIdnaEncode( string $domain, string $expected ) {
+		$this->assertSame( $expected, idna_encode( $domain ) );
+	}
+
+	/**
+	 * Test the module has no PSR-0 Requests class references left.
+	 *
+	 * The PSR-0 `Requests_*` names are deprecated aliases; referencing one emits
+	 * an E_USER_DEPRECATED from the Requests autoloader. That notice is silenced
+	 * after the first occurrence in a request, so asserting on the deprecation
+	 * itself would be order-dependent -- scan the source instead.
+	 *
+	 * @return void
+	 */
+	public function testNoLegacyRequestsClassNames() {
+		$inc_dir = dirname( __DIR__, 3 ) . '/inc';
+		$files = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $inc_dir ) );
+		$offenders = [];
+
+		foreach ( $files as $file ) {
+			if ( $file->getExtension() !== 'php' ) {
+				continue;
+			}
+
+			$contents = file_get_contents( $file->getPathname() );
+
+			if ( preg_match( '/\bRequests_[A-Za-z_]+/', $contents ) ) {
+				$offenders[] = str_replace( $inc_dir . '/', '', $file->getPathname() );
+			}
+		}
+
+		$this->assertSame( [], $offenders, 'No PSR-0 Requests_* class names should remain in inc/.' );
+	}
+}

--- a/tests/integration/add-site-ui/IdnaEncodeTest.php
+++ b/tests/integration/add-site-ui/IdnaEncodeTest.php
@@ -76,6 +76,10 @@ class IdnaEncodeTest extends \Codeception\TestCase\WPTestCase {
 
 			$contents = file_get_contents( $file->getPathname() );
 
+			// A false return would coerce to an empty string and silently scan
+			// as clean, which would make this test pass for the wrong reason.
+			$this->assertNotFalse( $contents, sprintf( 'Could not read %s', $file->getPathname() ) );
+
 			if ( preg_match( '/\bRequests_[A-Za-z_]+/', $contents ) ) {
 				$offenders[] = str_replace( $inc_dir . '/', '', $file->getPathname() );
 			}


### PR DESCRIPTION
- Fixes humanmade/product-dev#2269

The PSR-0 `Requests_*` class names have been deprecated aliases since WordPress 6.2, and referencing one makes the Requests autoloader emit:

```
    Deprecated: The PSR-0 Requests_... class names in the Requests library are deprecated. Switch to the PSR-4 WpOrg\Requests\... class names at your earliest convenience.
```

`idna_encode()` is called on every load and submit of Network Admin -> Sites -> Add New, so the notice showed up throughout WP 7.1 testing.

`Requests_IDNAEncoder` is a class_alias for `WpOrg\Requests\IdnaEncoder` (note the PSR-4 casing), so this is a rename with no behaviour change. The new integration test pins that: its expectations are the values the PSR-0 name produced.

