### PR TITLE
Don't pass null to trim() for a custom domain with no path

### DIFF
--- a/inc/add_site_ui/namespace.php
+++ b/inc/add_site_ui/namespace.php
@@ -501,7 +501,7 @@ function handle_custom_domain( string $url ) : ?array {
 	}
 
 	$domain = trim( $url_array['host'], '.' );
-	$path = trim( $url_array['path'], '/' );
+	$path = trim( $url_array['path'] ?? '', '/' );
 
 	return [
 		'domain' => idna_encode( $domain ),

--- a/tests/integration.suite.yml
+++ b/tests/integration.suite.yml
@@ -1,0 +1,9 @@
+# Codeception Test Suite Configuration
+#
+# Suite for unit or integration tests that require WordPress functions and classes.
+
+actor: IntegrationTester
+modules:
+    enabled:
+        - WPLoader
+        - \Helper\Integration

--- a/tests/integration/add-site-ui/HandleCustomDomainTest.php
+++ b/tests/integration/add-site-ui/HandleCustomDomainTest.php
@@ -23,7 +23,7 @@ class HandleCustomDomainTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Custom domain inputs and their expected domain and path.
 	 *
-	 * The function wp_parse_url() omits the `path` key entirely for a bare domain, 
+	 * The function wp_parse_url() omits the `path` key entirely for a bare domain,
 	 * which is the common case when a super admin adds a site by custom domain.
 	 *
 	 * @return array<string, array{0: string, 1: array}>

--- a/tests/integration/add-site-ui/HandleCustomDomainTest.php
+++ b/tests/integration/add-site-ui/HandleCustomDomainTest.php
@@ -23,8 +23,8 @@ class HandleCustomDomainTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Custom domain inputs and their expected domain and path.
 	 *
-	 * wp_parse_url() omits the `path` key entirely for a bare domain, which is
-	 * the common case when a super admin adds a site by custom domain.
+	 * The function wp_parse_url() omits the `path` key entirely for a bare domain, 
+	 * which is the common case when a super admin adds a site by custom domain.
 	 *
 	 * @return array<string, array{0: string, 1: array}>
 	 */

--- a/tests/integration/add-site-ui/HandleCustomDomainTest.php
+++ b/tests/integration/add-site-ui/HandleCustomDomainTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Test the Add Site UI custom domain handler.
+ *
+ * phpcs:disable WordPress.Files, HM.Files, HM.Functions.NamespacedFunctions, WordPress.NamingConventions
+ */
+
+namespace AddSiteUI;
+
+use function Altis\CMS\Add_Site_UI\handle_custom_domain;
+
+/**
+ * Test the Add Site UI custom domain handler.
+ */
+class HandleCustomDomainTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * Tester
+	 *
+	 * @var \IntegrationTester
+	 */
+	protected $tester;
+
+	/**
+	 * Custom domain inputs and their expected domain and path.
+	 *
+	 * wp_parse_url() omits the `path` key entirely for a bare domain, which is
+	 * the common case when a super admin adds a site by custom domain.
+	 *
+	 * @return array<string, array{0: string, 1: array}>
+	 */
+	public function domainProvider() : array {
+		return [
+			'bare domain, no path' => [
+				'example.com',
+				[
+					'domain' => 'example.com',
+					'path' => '/',
+				],
+			],
+			'bare non-ascii domain, no path' => [
+				'exämple.com',
+				[
+					'domain' => 'xn--exmple-cua.com',
+					'path' => '/',
+				],
+			],
+			'domain with a path' => [
+				'https://example.com/blog',
+				[
+					'domain' => 'example.com',
+					'path' => '/blog',
+				],
+			],
+			'domain with a trailing slash' => [
+				'https://example.com/',
+				[
+					'domain' => 'example.com',
+					'path' => '/',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test custom domains resolve without warnings.
+	 *
+	 * @dataProvider domainProvider
+	 *
+	 * @param string $url      The custom domain input.
+	 * @param array  $expected The expected domain and path.
+	 *
+	 * @return void
+	 */
+	public function testHandleCustomDomain( string $url, array $expected ) {
+		$this->assertSame( $expected, handle_custom_domain( $url ) );
+	}
+}


### PR DESCRIPTION
- Fixes #1000 

### Tests

Adds an integration suite to this module (`tests/integration.suite.yml`, copied from `altis/core`'s) plus `HandleCustomDomainTest.php`, covering a bare domain, a bare non-ASCII domain, a domain with a path, and a domain with a trailing slash.

### Verified

Against a local Altis on WordPress 7.1:

```
'example.com'              => {"domain":"example.com","path":"/"}
'exämple.com'              => {"domain":"xn--exmple-cua.com","path":"/"}
'https://example.com/blog' => {"domain":"example.com","path":"/blog"}
'https://example.com/'     => {"domain":"example.com","path":"/"}
diagnostics: 0
```

Same four inputs before the change produce the warning and deprecation above for the two
bare-domain cases.

---

## For Altis Team Use

### Completion Checklist
Does this PR meet our definition of done? See [the Play Book Definition of Done](https://playbook.hmn.md/play/product/definition-of-done-2/)

- [x] Has the acceptance criteria been met?
- [ ] Is the documentation updated (including README)?
- [x] Do any code/documentation changes meet project standards?
- [x] Are automatic tests in place to verify the fix or new functionality?
    - [x] OR, are manual tests documented (at least on the ticket/PR)?
- [ ] Are any Playbook/Handbook pages updated?
- [ ] Has a new module release (patch/minor) been created/scheduled?
- [x] Have the appropriate `backport` labels been added to the PR?
- [ ] Is there a roll-out (and roll-back) plan, if required?