### PR TITLE
Update Dependabot for v28 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,22 @@ updates:
   allow:
   - dependency-type: "direct"
   versioning-strategy: "increase"
+  target-branch: v28-branch
+  commit-message:
+    prefix: "[v28-branch]"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: "direct"
+  versioning-strategy: "increase"
   target-branch: v27-branch
   commit-message:
     prefix: "[v27-branch]"
@@ -53,22 +69,6 @@ updates:
   target-branch: v25-branch
   commit-message:
     prefix: "[v25-branch]"
-  ignore:
-    - dependency-name: "*"
-      update-types:
-        - "version-update:semver-major"
-        - "version-update:semver-minor"
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: "direct"
-  versioning-strategy: "increase"
-  target-branch: v24-branch
-  commit-message:
-    prefix: "[v24-branch]"
   ignore:
     - dependency-name: "*"
       update-types:


### PR DESCRIPTION
This PR updates Dependabot configuration to add the v28 branch.